### PR TITLE
Typo of mentioning the wrong variable was fixed

### DIFF
--- a/src/Doc/Generic2.md
+++ b/src/Doc/Generic2.md
@@ -80,7 +80,7 @@ vectInfo = getInfo "Vect"
 ```
 
 ```
-...> :exec putPretty eitherInfo
+...> :exec putPretty vectInfo
 
   MkTypeInfo Data.Vect.Vect
              [ (MW ExplicitArg len : IVar Prelude.Types.Nat)


### PR DESCRIPTION
`vectInfo` instead of repeating the `eitherInfo`