### PR TITLE
[ fix ] parameter handling in constraints

### DIFF
--- a/elab-util-docs.ipkg
+++ b/elab-util-docs.ipkg
@@ -1,7 +1,7 @@
 package elab-util-docs
 
 authors    = "stefan-hoeck"
-version    = 0.1.2
+version    = 0.2.0
 readme     = "README.md"
 license    = "BSD-2 Clause"
 

--- a/elab-util.ipkg
+++ b/elab-util.ipkg
@@ -1,7 +1,7 @@
 package elab-util
 
 authors    = "stefan-hoeck"
-version    = 0.1.2
+version    = 0.2.0
 readme     = "README.md"
 license    = "BSD-2 Clause"
 

--- a/src/Doc/Generic4.md
+++ b/src/Doc/Generic4.md
@@ -51,7 +51,7 @@ private
 genericUtil : ParamTypeInfo -> DeriveUtil
 genericUtil ti = let pNames = map fst $ params ti
                      appTpe = appNames (name ti) pNames
-                     twps   = concatMap hasParamTypes ti.cons
+                     twps   = calcArgTypesWithParams ti
                   in MkDeriveUtil ti appTpe pNames twps
 
 export


### PR DESCRIPTION
When automatically deriving interface implementations for parameterized types, it is not always clear how to calculate the set of constraints for an implementation from the parameters. Consider for instance the following data type:

```idris
record Foo a b where
  constructor MkFoo
  bars : List a
  bazes : List b
```

Clearly, the `Eq` instance of `Foo` should use the following constraints:

```idris
(Eq a, Eq b) => Eq (Foo a b) where
```

Its `Semigroup` instance, however, should come without any constraints:

```idris
Semigroup (Foo a b) where
```

For higher kinded parameters, the issue gets more comples:

```idris
data A : (f : Type -> Type -> Type) -> (a : Type) -> Type where
  ConA : f Int -> A f a
  ConB : f String -> a -> A f a

(Eq (f Int), Eq (f String), Eq a) => Eq (A f a) where
```
Clearly, there is not a single valid strategy for calculating the set of constraints for all interface implementations. There will always be occasions, where client code has to manually provide this set.

This PR takes a new - more conservative - approach towards calculating this set of constraints in the hope that the deriving of core interfaces like `Eq` and `Show` works out of the box in more occasions.