### PR TITLE
[ totality ] Make all the modules as total as possible.

### DIFF
--- a/src/Language/Reflection/Derive.idr
+++ b/src/Language/Reflection/Derive.idr
@@ -11,6 +11,8 @@ import public Language.Reflection.Types
 
 %language ElabReflection
 
+%default total
+
 ||| Utility type for deriving interface implementations
 ||| automatically. See implementations of `Eq'` and `Ord'`
 ||| in Doc.Generic4 as examples, how this can be done.

--- a/src/Language/Reflection/Pretty.idr
+++ b/src/Language/Reflection/Pretty.idr
@@ -21,6 +21,8 @@ import public Language.Reflection
 import public Text.PrettyPrint.Prettyprinter
 import Text.PrettyPrint.Prettyprinter.Render.String
 
+%default total
+
 --------------------------------------------------------------------------------
 --          Utils
 --------------------------------------------------------------------------------
@@ -254,6 +256,8 @@ Pretty DataOpt where
   prettyPrec _ NoNewtype     = "NoNewtype"
 
 mutual
+
+  %default covering
 
   export
   Pretty IFieldUpdate where

--- a/src/Language/Reflection/Refined.idr
+++ b/src/Language/Reflection/Refined.idr
@@ -6,6 +6,8 @@ import public Data.Maybe
 import public Data.So
 import public Language.Reflection.Derive
 
+%default total
+
 --------------------------------------------------------------------------------
 --          Utilities
 --------------------------------------------------------------------------------
@@ -42,7 +44,7 @@ refineSo make val = case maybeSo (f val) of
 |||
 ||| %runElab refinedEq "AtomicNr" `{{value}}
 ||| ```
-export covering
+export
 refinedEq : (dataType : String) -> (accessor : Name) -> Elab ()
 refinedEq dt accessor =
   let eqFun   = UN $ "implEq"   ++ dt
@@ -68,7 +70,7 @@ refinedEq dt accessor =
 |||
 ||| %runElab refinedOrd "AtomicNr" `{{value}}
 ||| ```
-export covering
+export
 refinedOrd : (dataType : String) -> (accessor : Name) -> Elab ()
 refinedOrd dt accessor =
   let ordFun  = UN $ "implOrd"  ++ dt
@@ -95,7 +97,7 @@ refinedOrd dt accessor =
 |||
 ||| %runElab refinedShow "AtomicNr" `{{value}}
 ||| ```
-export covering
+export
 refinedShow : (dataType : String) -> (accessor : Name) -> Elab ()
 refinedShow dt accessor =
   let showFun = UN $ "implShow" ++ dt
@@ -111,7 +113,7 @@ refinedShow dt accessor =
 
 ||| Convenience function combining `refinedEq`, `refinedOrd`,
 ||| and `refinedShow`.
-export covering
+export
 refinedEqOrdShow : (dataType : String) -> (accessor : Name) -> Elab ()
 refinedEqOrdShow dt acc = do refinedEq dt acc
                              refinedOrd dt acc
@@ -157,7 +159,7 @@ refinedEqOrdShow dt acc = do refinedEq dt acc
 |||               -> AtomicNr
 |||   fromInteger v = fromJust (refine $ fromInteger v)
 ||| ```
-export covering
+export
 refinedIntegral :  (dataType : String)
                 -> (con      : Name)
                 -> (accessor : Name)
@@ -201,7 +203,7 @@ refinedIntegral dt con acc tpe =
 |||
 ||| %runElab refinedInt "AtomicNr"
 ||| ```
-export covering
+export
 refinedInt : (dataType : String) -> Elab ()
 refinedInt dt = refinedIntegral dt (UN $ "Mk" ++ dt) `{{value}} `(Int)
 
@@ -211,7 +213,7 @@ refinedInt dt = refinedIntegral dt (UN $ "Mk" ++ dt) `{{value}} `(Int)
 |||  * If a data type's name is `Foo` its constructor is named `MkFoo`.
 |||  * The field accessor of the wrapped Int is named `value`.
 |||  * The proof of validity consists of a single zero quantity `So`.
-export covering
+export
 refinedBits8 : (dataType : String) -> Elab ()
 refinedBits8 dt = refinedIntegral dt (UN $ "Mk" ++ dt) `{{value}} `(Bits8)
 
@@ -221,7 +223,7 @@ refinedBits8 dt = refinedIntegral dt (UN $ "Mk" ++ dt) `{{value}} `(Bits8)
 |||  * If a data type's name is `Foo` its constructor is named `MkFoo`.
 |||  * The field accessor of the wrapped Int is named `value`.
 |||  * The proof of validity consists of a single zero quantity `So`.
-export covering
+export
 refinedBits16 : (dataType : String) -> Elab ()
 refinedBits16 dt = refinedIntegral dt (UN $ "Mk" ++ dt) `{{value}} `(Bits16)
 
@@ -231,7 +233,7 @@ refinedBits16 dt = refinedIntegral dt (UN $ "Mk" ++ dt) `{{value}} `(Bits16)
 |||  * If a data type's name is `Foo` its constructor is named `MkFoo`.
 |||  * The field accessor of the wrapped Int is named `value`.
 |||  * The proof of validity consists of a single zero quantity `So`.
-export covering
+export
 refinedBits32 : (dataType : String) -> Elab ()
 refinedBits32 dt = refinedIntegral dt (UN $ "Mk" ++ dt) `{{value}} `(Bits32)
 
@@ -241,7 +243,7 @@ refinedBits32 dt = refinedIntegral dt (UN $ "Mk" ++ dt) `{{value}} `(Bits32)
 |||  * If a data type's name is `Foo` its constructor is named `MkFoo`.
 |||  * The field accessor of the wrapped Int is named `value`.
 |||  * The proof of validity consists of a single zero quantity `So`.
-export covering
+export
 refinedBits64 : (dataType : String) -> Elab ()
 refinedBits64 dt = refinedIntegral dt (UN $ "Mk" ++ dt) `{{value}} `(Bits64)
 
@@ -283,7 +285,7 @@ refinedBits64 dt = refinedIntegral dt (UN $ "Mk" ++ dt) `{{value}} `(Bits64)
 |||              -> Abundance
 |||   fromDouble v = fromJust (refine v)
 ||| ```
-export covering
+export
 refinedFloating :  (dataType : String)
                 -> (con      : Name)
                 -> (accessor : Name)
@@ -317,7 +319,7 @@ refinedFloating dt con acc =
 |||  * If a data type's name is `Foo` its constructor is named `MkFoo`.
 |||  * The field accessor of the wrapped Int is named `value`.
 |||  * The proof of validity consists of a single zero quantity `So`.
-export covering
+export
 refinedDouble : (dataType : String) -> Elab ()
 refinedDouble dt = refinedFloating dt (UN $ "Mk" ++ dt) `{{value}}
 
@@ -358,7 +360,7 @@ refinedDouble dt = refinedFloating dt (UN $ "Mk" ++ dt) `{{value}}
 |||              -> Html
 |||   fromString v = fromJust (refine v)
 ||| ```
-export covering
+export
 refinedText :  (dataType : String)
             -> (con      : Name)
             -> (accessor : Name)
@@ -392,6 +394,6 @@ refinedText dt con acc =
 |||  * If a data type's name is `Foo` its constructor is named `MkFoo`.
 |||  * The field accessor of the wrapped Int is named `value`.
 |||  * The proof of validity consists of a single zero quantity `So`.
-export covering
+export
 refinedString : (dataType : String) -> Elab ()
 refinedString dt = refinedText dt (UN $ "Mk" ++ dt) `{{value}}

--- a/src/Language/Reflection/Types.idr
+++ b/src/Language/Reflection/Types.idr
@@ -9,6 +9,8 @@ import Text.PrettyPrint.Prettyprinter
 
 %language ElabReflection
 
+%default total
+
 --------------------------------------------------------------------------------
 --          Utilities
 --------------------------------------------------------------------------------
@@ -48,6 +50,7 @@ getCon n = do (n',tt)    <- lookupName n
               pure $ MkCon n' args tpe
 
 export
+covering
 Pretty Con where
   prettyPrec p (MkCon n args tpe) = applyH p "MkCon" [n, args, tpe]
 
@@ -67,6 +70,7 @@ record TypeInfo where
   cons : List Con
 
 export
+covering
 Pretty TypeInfo where
   pretty (MkTypeInfo name args cons) =
     let head = applyH Open "MkTypeInfo" [name, args]
@@ -141,6 +145,7 @@ record ExplicitArg where
   isRecursive : Bool
 
 export
+covering
 Pretty ExplicitArg where
   prettyPrec p (MkExplicitArg n tpe paramTypes isRecursive) =
     applyH p "MkExplicitArg" [n, tpe, paramTypes, isRecursive]
@@ -161,6 +166,7 @@ record ParamCon where
   explicitArgs : List ExplicitArg
 
 export
+covering
 Pretty ParamCon where
   prettyPrec p (MkParamCon n explicitArgs) =
     applyH p "MkParamCon" [n, explicitArgs]
@@ -218,6 +224,7 @@ record ParamTypeInfo where
   cons   : List ParamCon
 
 export
+covering
 Pretty ParamTypeInfo where
   pretty (MkParamTypeInfo name params cons) =
     let head = applyH Open "MkParamTypeInfo" [name, toList params]


### PR DESCRIPTION
Some `Pretty` instances are left `covering` because the compilation time becomes too big.
But the rest of the library was made to be checked for totality.

This PR actually depends on https://github.com/idris-lang/Idris2/pull/1409.