### PR TITLE
[ fix ] Make RHS of a bind (with `assert_total`) to be lambda explicitly

### DIFF
--- a/src/Language/Reflection/Syntax.idr
+++ b/src/Language/Reflection/Syntax.idr
@@ -458,5 +458,5 @@ lookupName : Name -> Elab (Name, TTImp)
 lookupName n = do pairs <- getType n
                   case (pairs,n) of
                        ([p],_)     => pure p
-                       (ps,UN str) => inCurrentNS (UN str) >>= assert_total {-now argument is NS, not UN-} lookupName
+                       (ps,UN str) => inCurrentNS (UN str) >>= \m => assert_total {-now argument is NS, not UN-} $ lookupName m
                        (ps,_)      => fail $ errMsg n ps


### PR DESCRIPTION
After introducing the `assert_total` to the `lookupName` I didn't figure out that `assert_total lookupName` does not reduce to a lambda unlike bare `lookupName` was. This led to a "bad elaboration script" error instead of "X is not in scope" one.

Well, probably it would be better to fix the compiler to reduce stuff with a `assert_total` better. This fix is a workaround anyway, so why don't we fix it for the current state of the compiler (since I don't know how much time it would take to figure out the reason why doesn't the compiler reduces `assert_total f` to a lambda well).