### PR TITLE
[ compat ] Make a signature to be future-compatible with upstream update

### DIFF
--- a/src/Language/Reflection/Syntax.idr
+++ b/src/Language/Reflection/Syntax.idr
@@ -269,7 +269,7 @@ export
 
 ||| Extracts the arguments from a function type.
 export
-piAll : TTImp -> List $ Arg False -> TTImp
+piAll : TTImp -> List (Arg False) -> TTImp
 piAll res = foldr (.->) res
 
 ||| Extracts the arguments from a function type.


### PR DESCRIPTION
As soon as 1711 merged, and the priorities of `$` and `->` in signatures are changed, the current code does not compile. Let's fix it in a backward-compatible way! ;-)