### PR TITLE
[ CI ] only test against latest Idris

### DIFF
--- a/.github/workflows/ci-lib.yml
+++ b/.github/workflows/ci-lib.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
   schedule:
     # We want to run right after the `latest` image is published.
     # So, let's do it an hour right after. Look the schedule of publishing here:
@@ -22,31 +21,12 @@ defaults:
 
 jobs:
 
-  read-ver:
-    name: Aquire compiler version
-    runs-on: ubuntu-latest
-    env:
-      IDRIS_VERSION_FILE: .idris-version
-    outputs:
-      idris-ver: ${{ steps.read-ver.outputs.idris-ver }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Read the version
-        id: read-ver
-        run: sed 's/^/::set-output name=idris-ver::/' < "${IDRIS_VERSION_FILE}"
-
   build:
-    name: Build the lib with ${{ matrix.idris-version }}
-    needs: read-ver
+    name: Build the lib with Idris2 HEAD
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        idris-version:
-          - ${{ needs.read-ver.outputs.idris-ver }}
-          - latest
-    container: snazzybucket/idris2api:${{ matrix.idris-version }}
+    container: snazzybucket/idris2api:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -28,5 +28,9 @@ Starting from Idris2 version 0.5.1, tagged releases of the same
 minor version number (e.g. 0.5.x) will be made available, while the main
 branch keeps following the Idris2 main branch
 
-The latest commit has been built against Idris 2 of version set in the ``.idris-version`` file.
-This file contains a version in the format which ``git describe --tags`` gives.
+The latest commit is daily tested to build against the current
+HEAD of the Idris compiler. Since Idris2 releases are happening
+rather infrequently at the moment, it is suggested to use
+a package manager like [pack](https://github.com/stefan-hoeck/idris2-pack)
+to install and maintain matching versions of the Idris compiler
+and this library.


### PR DESCRIPTION
This turns off testing against a fixed commit of Idris to ease the maintenance burden in case of breaking compiler updates. The library is still being tested nightly against Idris2 latest. It will also be tested automatically be pack's GitHub actions when building nightly package collections.

@buzden : Since you setup the GitHub actions for this repo, may I kindly ask you to have a look at this?