### PR TITLE
Update reflection code to be compatible with Idris2#2535

### DIFF
--- a/src/Language/Reflection/Pretty.idr
+++ b/src/Language/Reflection/Pretty.idr
@@ -380,7 +380,7 @@ mutual
     prettyPrec p (ILet _ _ cnt name nTy nVal scope) =
       applyH p "ILet" [cnt,name,nTy,nVal,scope]
 
-    prettyPrec p (ICase _ arg ty cs) = applyH p "ICase" [arg,ty,cs]
+    prettyPrec p (ICase _ mrig arg ty cs) = applyH p "ICase" [mrig,arg,ty,cs]
 
     prettyPrec p (ILocal _ decls tt) =
       indentLines (apply p "ILocal" [tt]) (map pretty decls)

--- a/src/Language/Reflection/Syntax.idr
+++ b/src/Language/Reflection/Syntax.idr
@@ -307,7 +307,7 @@ export
 ||| This is an alias for `ICase EmptyFC`.
 export
 iCase : TTImp -> (ty : TTImp) -> List Clause -> TTImp
-iCase = ICase EmptyFC
+iCase = ICase EmptyFC MW -- Should probably be `Nothing`
 
 ||| "as"-pattern.
 |||


### PR DESCRIPTION
[Idris2#2535](github.com/idris-lang/Idris2/pull/2535) adds a quantity
argument to PCase and ICase. Update the reflection code to include
this additional argument.

The fix in `src/Language/Reflection/Syntax.idr` is only temporary, I
think the correct fix there should be a `Nothing` on the quantity,
or alternatively fix downstream from it, requiring a quantity
annotation. I'm using the easy fix first, but might update this PR
with the downstream fix once I have a look around the code-base. (Or
if someone else who knows the codebase wants to do it, I'm happy to
take a step back!)

Don't merge this commit into main until #2535 is merged and
incorproated into the nightly build.