### PR TITLE
[ refactor] derive under elab so that additional queries and error reporting can be done

### DIFF
--- a/elab-util.ipkg
+++ b/elab-util.ipkg
@@ -1,7 +1,7 @@
 package elab-util
 
 authors    = "stefan-hoeck"
-version    = 0.5.0
+version    = 0.6.0
 readme     = "README.md"
 license    = "BSD-2 Clause"
 

--- a/src/Doc/Generic5.md
+++ b/src/Doc/Generic5.md
@@ -51,8 +51,8 @@ of type safety back:
 mkEq : (eq : a -> a -> Bool) -> Eq a
 mkEq eq = mkEq' eq (\a,b => not $ eq a b)
 
-Eq' : DeriveUtil -> InterfaceImpl
-Eq' g = MkInterfaceImpl "Eq" Public [] `(mkEq genEq) (implementationType `(Eq) g)
+Eq' : DeriveUtil -> Elab InterfaceImpl
+Eq' g = pure $ MkInterfaceImpl "Eq" Public [] `(mkEq genEq) (implementationType `(Eq) g)
 ```
 
 This time, we used utilities from `Language.Reflection.Derive`.
@@ -84,9 +84,9 @@ mkOrd comp = mkOrd' comp
                     (\a,b => if comp a b == GT then a else b)
                     (\a,b => if comp a b == LT then a else b)
 
-Ord' : DeriveUtil -> InterfaceImpl
-Ord' g = MkInterfaceImpl "Ord" Public [] `(mkOrd genCompare)
-                                         (implementationType `(Ord) g)
+Ord' : DeriveUtil -> Elab InterfaceImpl
+Ord' g = pure $ MkInterfaceImpl "Ord" Public [] `(mkOrd genCompare)
+                                                (implementationType `(Ord) g)
 ```
 
 We quickly test if it works:

--- a/src/Doc/Generic7.md
+++ b/src/Doc/Generic7.md
@@ -120,8 +120,8 @@ conNames (MkParamCon con args) = let ns   = map (nameStr . name) args
 ||| Derives a `Generic` implementation for the given data type
 ||| and visibility.
 export
-GenericVis : Visibility -> DeriveUtil -> InterfaceImpl
-GenericVis vis g =
+GenericVis : Visibility -> DeriveUtil -> Elab InterfaceImpl
+GenericVis vis g = pure $
   let names    = zipWithIndex (map conNames g.typeInfo.cons)
       genType  = `(Generic) .$ g.appliedType .$ mkCode g.typeInfo
       funType  = piAllImplicit  genType g.paramNames
@@ -139,7 +139,7 @@ GenericVis vis g =
 
 ||| Alias for `GenericVis Public`.
 export
-Generic' : DeriveUtil -> InterfaceImpl
+Generic' : DeriveUtil -> Elab InterfaceImpl
 Generic' = GenericVis Public
 ```
 
@@ -220,15 +220,15 @@ mkEqV :  Eq a
       -> EqV a
 mkEqV = %runElab check (var $ singleCon "EqV")
 
-Eq' : DeriveUtil -> InterfaceImpl
-Eq' g = MkInterfaceImpl "Eq" Public []
-          `(mkEq genEq)
-          (implementationType `(Eq) g)
+Eq' : DeriveUtil -> Elab InterfaceImpl
+Eq' g = pure $ MkInterfaceImpl "Eq" Public []
+                 `(mkEq genEq)
+                 (implementationType `(Eq) g)
 
-EqV' : DeriveUtil -> InterfaceImpl
-EqV' g = MkInterfaceImpl "EqV" Public []
-        `(mkEqV genEqRefl genEqSym genEqTrans (\_,_ => Refl))
-        (implementationType `(EqV) g)
+EqV' : DeriveUtil -> Elab InterfaceImpl
+EqV' g = pure $ MkInterfaceImpl "EqV" Public []
+                  `(mkEqV genEqRefl genEqSym genEqTrans (\_,_ => Refl))
+                  (implementationType `(EqV) g)
 
 data AnotherSum : Type where
   Var   : (v : String) -> AnotherSum


### PR DESCRIPTION
While working on some tooling using elab-util I've found I need more power available at the call site for queries about what's in scope and for the ability to report errors along the way, updating `derive` to return a value under Elab was the most direct solution I could find to the problem.