### PR TITLE
[ upstream ] Adapt to the idris-lang/Idris2#2604

### DIFF
--- a/.github/workflows/ci-lib.yml
+++ b/.github/workflows/ci-lib.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    container: snazzybucket/idris2api:latest
+    container: snazzybucket/idris2:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/Doc/Generic4.md
+++ b/src/Doc/Generic4.md
@@ -212,7 +212,6 @@ from `Language.Reflection.TT` and `Language.Reflection.TTImp`.
 %runElab (derive "Namespace"   [Generic', Eq', Ord'])
 %runElab (derive "UserName"    [Generic', Eq', Ord'])
 %runElab (derive "Name"        [Generic', Eq', Ord'])
-%runElab (derive "NoMangleDirective"    [Generic', Eq', Ord'])
 %runElab (derive "Count"       [Generic', Eq', Ord'])
 %runElab (derive "LazyReason"  [Generic', Eq', Ord'])
 %runElab (derive "PiInfo"      [Generic', Eq', Ord'])

--- a/src/Language/Reflection/Pretty.idr
+++ b/src/Language/Reflection/Pretty.idr
@@ -298,15 +298,9 @@ mutual
     prettyPrec p (UniqueDefault x) = apply p "UniqueDefault" [x]
 
   export
-  Pretty NoMangleDirective where
-    prettyPrec p (CommonName x)   = apply p "CommonName" [x]
-    prettyPrec p (BackendNames x) = apply p "BackendNames" [x]
-
-  export
   Pretty FnOpt where
     prettyPrec _ Inline         = "Inline"
     prettyPrec _ NoInline       = "NoInline"
-    prettyPrec p (NoMangle x)   = apply p "NoMangle" [x]
     prettyPrec _ TCInline       = "TCInline"
     prettyPrec _ Deprecate      = "Deprecate"
     prettyPrec p (Hint x)       = apply p "Hint" [x]


### PR DESCRIPTION
Compiler's PR idris-lang/Idris2#2604 was merged with red CI because of `elab-util`, this should fix it.