### PR TITLE
Fix misc. typos, indentation, missing words, etc.

### DIFF
--- a/src/Doc/Enum1.md
+++ b/src/Doc/Enum1.md
@@ -78,7 +78,7 @@ constants. In addition, it comes with infix operators
 similar to the ones shown in the pretty printer for
 defining function application, type declarations and
 anonymous functions. Finally, a handy `FromString`
-instance for `Name` is provided, which determins from
+instance for `Name` is provided, which determines from
 the string passed whether the name is fully qualified or not.
 
 ```idris

--- a/src/Doc/Enum2.md
+++ b/src/Doc/Enum2.md
@@ -111,9 +111,9 @@ From the [implementation notes](https://idris2.readthedocs.io/en/latest/implemen
 we learn that interfaces are translated to records and
 implementations to search hints, so we might try to create
 such a record value manually. All interfaces in `prelude`
-and `base` have been given properly named constructor recently,
+and `base` have been given properly named constructors recently,
 so creating an `Eq` value manually is very easy.
-For interfaces without explicit constructor we can use
+For interfaces without an explicit constructor we can use
 `getInfo` to inspect the type at hand:
 
 ```idris

--- a/src/Doc/Generic1.md
+++ b/src/Doc/Generic1.md
@@ -256,7 +256,7 @@ toClauses cs = map toClause cs ++
 
 A quick note about function `nameStr`: Idris does not accept
 the machine-generated names of unnamed arguments in pattern matches.
-Function `nameStr` converts such names to similar user-defined names.
+The function `nameStr` converts such names to similar user-defined names.
 
 ```idris
 private

--- a/src/Doc/Generic3.md
+++ b/src/Doc/Generic3.md
@@ -34,7 +34,7 @@ mkCode = listOf . map (listOf . map tpe . explicitArgs) . cons
 The implementation of `genericDecl`, however, requires an
 additional step: In the definition of the function type,
 we must include the type parameters as implicit arguments.
-Utility function `piAllImplicit` helps with this part.
+The utility function `piAllImplicit` helps with this part.
 
 ```idris
 export

--- a/src/Doc/Generic4.md
+++ b/src/Doc/Generic4.md
@@ -150,7 +150,7 @@ the `Eq` instance of `Maybe` has the following type:
 {0 a: _} -> Eq a => Eq (Maybe a)
 ```
 
-We define function `implementationType` to set up this type
+We define the function `implementationType` to set up this type
 for us:
 
 ```idris
@@ -204,25 +204,25 @@ from `Language.Reflection.TT` and `Language.Reflection.TTImp`.
 ```idris
 %runElab (derive "ModuleIdent"  [Generic', Eq', Ord'])
 %runElab (derive "VirtualIdent" [Generic', Eq', Ord'])
-%runElab (derive "OriginDesc"  [Generic', Eq', Ord'])
-%runElab (derive "FC"          [Generic', Eq', Ord'])
-%runElab (derive "NameType"    [Generic', Eq', Ord'])
-%runElab (derive "PrimType"    [Generic', Eq', Ord'])
-%runElab (derive "Constant"    [Generic', Eq', Ord'])
-%runElab (derive "Namespace"   [Generic', Eq', Ord'])
-%runElab (derive "UserName"    [Generic', Eq', Ord'])
-%runElab (derive "Name"        [Generic', Eq', Ord'])
-%runElab (derive "Count"       [Generic', Eq', Ord'])
-%runElab (derive "LazyReason"  [Generic', Eq', Ord'])
-%runElab (derive "PiInfo"      [Generic', Eq', Ord'])
-%runElab (derive "BindMode"    [Generic', Eq', Ord'])
-%runElab (derive "UseSide"     [Generic', Eq', Ord'])
-%runElab (derive "DotReason"   [Generic', Eq', Ord'])
-%runElab (derive "Visibility"  [Generic', Eq', Ord'])
-%runElab (derive "TotalReq"    [Generic', Eq', Ord'])
-%runElab (derive "DataOpt"     [Generic', Eq', Ord'])
-%runElab (derive "WithFlag"    [Generic', Eq', Ord'])
-%runElab (derive "BuiltinType" [Generic', Eq', Ord'])
+%runElab (derive "OriginDesc"   [Generic', Eq', Ord'])
+%runElab (derive "FC"           [Generic', Eq', Ord'])
+%runElab (derive "NameType"     [Generic', Eq', Ord'])
+%runElab (derive "PrimType"     [Generic', Eq', Ord'])
+%runElab (derive "Constant"     [Generic', Eq', Ord'])
+%runElab (derive "Namespace"    [Generic', Eq', Ord'])
+%runElab (derive "UserName"     [Generic', Eq', Ord'])
+%runElab (derive "Name"         [Generic', Eq', Ord'])
+%runElab (derive "Count"        [Generic', Eq', Ord'])
+%runElab (derive "LazyReason"   [Generic', Eq', Ord'])
+%runElab (derive "PiInfo"       [Generic', Eq', Ord'])
+%runElab (derive "BindMode"     [Generic', Eq', Ord'])
+%runElab (derive "UseSide"      [Generic', Eq', Ord'])
+%runElab (derive "DotReason"    [Generic', Eq', Ord'])
+%runElab (derive "Visibility"   [Generic', Eq', Ord'])
+%runElab (derive "TotalReq"     [Generic', Eq', Ord'])
+%runElab (derive "DataOpt"      [Generic', Eq', Ord'])
+%runElab (derive "WithFlag"     [Generic', Eq', Ord'])
+%runElab (derive "BuiltinType"  [Generic', Eq', Ord'])
 ```
 
 ~~It seems not yet to be possible, to use this method in a mutual
@@ -231,8 +231,8 @@ of boilerplate for `Eq` and `Ord` instances
 for the data types from `Language.Reflection.TTImp`~~.
 
 I finally figured out how to derive mutually dependant implementations.
-The core idea was to declare all implementation types first,
-before actually declaring implementations. This separation has
+The core idea was to declare all the implementation types first,
+before actually declaring the implementations. This separation has
 to occur in the `Elab` monad, as can be seen in the implementation
 of `deriveMutual`:
 

--- a/src/Doc/Generic5.md
+++ b/src/Doc/Generic5.md
@@ -60,7 +60,7 @@ They are very similar in functionality to the ones we developed in
 [Generics Part 4](Generic4.md). This
 approach is even more useful when deriving `Ord`: In our previous
 version we had to manually pass the `Eq` instance to the `Ord`
-constructor forcing us to get access to its implementation function
+constructor, forcing us to get access to its implementation function
 by means of `implName`. This is no longer necessary:
 
 ```idris
@@ -156,7 +156,7 @@ maxTest = Refl
 
 ## Conclusion
 
-In this very short tutorial we learned that
+In this very short tutorial we learned that the
 function `check` is useful whenever we try to implement
 a function using elaborator reflection whose type is already known at compile time.
 This was not the case for automatically derived interface implementations

--- a/src/Doc/Generic6.md
+++ b/src/Doc/Generic6.md
@@ -2,8 +2,8 @@
 
 I've been planning to write this part of the tutorial
 about generics for quite some time, but the writing
-went not as smoothly as I thought it would. In the end I had
-to change how interfaces for `NP` and `SOP` are defined, experience
+didn't go as smoothly as I thought it would. In the end I had
+to change how interfaces for `NP` and `SOP` were defined, experience
 some unexpectedly long compilation times on the run, and change
 implementations once again, before I arrived at the solution
 presented in this post.
@@ -22,7 +22,7 @@ module Doc.Generic6
 
 When we are deriving interface implementations via `Generic`,
 we do so in a deterministic, predictable manner. It should therefore
-be possible - and desirable! - to at the same time proof
+be possible - and desirable! - to at the same time prove
 that our implementations adhere to the common laws expected
 for these interfaces. As an example, let's come up with some laws
 for `Eq`:
@@ -103,8 +103,8 @@ EqV a => EqV (Maybe a) where
   neqNotEq _ _ = Refl
 ```
 
-Great. A bit verbose, but we have to write these proofs
-only once. We might want to sprinkle in some implementations
+Great. A bit verbose, but we only have to write these proofs
+once. We might want to sprinkle in some implementations
 for primitives for good measure. For those, we have to
 convince Idris that we actually know what we are doing
 (I typically don't know what I'm doing, so if somebody
@@ -162,7 +162,7 @@ toAnd : a = True -> b = True -> a && Delay b = True
 toAnd ra rb = cong2 (&&) ra (cong delay rb)
 ```
 
-We are now ready to proof the correctness of `Eq` for
+We are now ready to prove the correctness of `Eq` for
 `Pair` and `Either`:
 
 ```idris
@@ -222,10 +222,10 @@ from `All EqV ts`. Luckily, Idris realized that the two tuples
 of interface instances might be completely unrelated:
 It refused to accept any implementation for `EqV`'s
 propositions. The problem: `EqV` should only be able
-to proof the correctness about the `Eq` instance
+to prove the correctness about the `Eq` instance
 that comes with itself. That's why we write
 `Eq a => EqV a` in our definition of `EqV`. And it should of course
-not be able to proof stuff about different, unrelated implementations
+not be able to prove stuff about different, unrelated implementations
 of `Eq` without somehow holding a reference to those implementations.
 But that is what we are trying to do with the above
 type declaration: The `Eq` implementation for `NP`
@@ -266,16 +266,16 @@ EqV t => EqV (NP ts) => EqV (NP (t :: ts)) where
 This works, and `EqV` instances can be implemented almost exactly
 the same way as for tuples above. However, since I'm using
 a similar design in [idris2-sop](https://github.com/stefan-hoeck/idris2-sop)
-I changed implementations there as well and soon realized that
+I changed implementations there as well and soon realized that the
 derived `Ord` implementations of some of my example data types
 suddenly took ages to typecheck. I quickly verified that
-the same is the case for `Data.HVect` from *contrib*, so I opened an
+the same was the case for `Data.HVect` from *contrib*, opened an
 [issue on idris-lang](https://github.com/idris-lang/Idris2/issues/783) about
 this and started looking for a way to get the original fast
 compilation times back while at the same time getting rid of the hacky
 (and wrong!) way to write interface implementations using `All`.
 Eventually, this led to a major rewrite of *idris2-sop*, which
-is why also in this post I will have to come up with new versions
+is also why in this post I will have to come up with new versions
 of `NP` and `SOP`.
 
 ## Adding some Flexibility to `NP`
@@ -363,7 +363,7 @@ testComp = compare
 
 This typechecks very quickly on my machine, so all seems
 to be fine.
-With that out of the way, we are ready to proof the correctness
+With that out of the way, we are ready to prove the correctness
 of `NP`'s `Eq` implementation.
 
 ## Verifying `Eq` for `NP`: Take Three
@@ -398,7 +398,7 @@ for pairs, of course.
 
 ## Verifying `Eq` for `SOP`
 
-It is now straight forward to write an implementation of `EqV`
+It is now straightforward to write an implementation of `EqV`
 for `SOP`. However, we need another data structure for
 wrapping our interface instances in:
 
@@ -467,7 +467,7 @@ public export
   compare {all = _::_} (S _)  (Z _)  = GT
 ```
 
-We now have the ingredients to proof the correctness of
+We now have the ingredients to prove the correctness of
 `SOP`'s `Eq` implementation:
 
 ```idris
@@ -506,7 +506,7 @@ All f [] = ()
 All f (t::ts) = (f t, All f ts)
 ```
 
-The advantage of this representation as nested pairs is that
+The advantage of this representation as nested pairs was that
 there was no need to explicitly pattern match on the pair's
 structure when implementing `Eq` and `Ord` for `NP` and `SOP`.
 However, it was also not possible to implement the following
@@ -518,7 +518,7 @@ allOrdToEq : All Ord ts -> All Eq ts
 
 without a way to pattern match on `ts` to get an idea
 about the underlying structure of `All Ord ts`.
-For this, we would have had to included `ts`
+For this, we would have had to include `ts`
 as a non-erased argument:
 
 ```repl
@@ -530,7 +530,7 @@ argument to our interface implementations (ugly!)
 but even then Idris refuses to accept a `%hint` annotation
 on `allOrdToEq` with the following error message:
 *Can only add hints for concrete return types*.
-Going via a well-structured data type resolved all these issues.
+Going via a well-structured data type resolves all these issues.
 
 ## What's next
 

--- a/src/Doc/Generic7.md
+++ b/src/Doc/Generic7.md
@@ -268,6 +268,6 @@ yet possible. Of course I will write about these things if
 I find working solutions.
 
 There will of course also be other use cases for elaborator
-reflection. I'm looking forward to learn something about
+reflection. I'm looking forward to learning something about
 using the technique for proof searching, for instance.
 Interesting results will be posted here, promise. :-)

--- a/src/Doc/Primitives.md
+++ b/src/Doc/Primitives.md
@@ -137,7 +137,7 @@ script much simpler:
 
 This allows us to generate the necessary declarations without much
 hassle. First, we generate declarations for the interface implementations.
-We can use functions `mkEq`, `mkOrd`, and `mkShow`
+We can use the functions `mkEq`, `mkOrd`, and `mkShow`
 from `Language.Reflection.Derive` and some utilities from
 `Language.Reflection.Syntax` here. The implementations themselves
 are just quoted versions of what we wrote above:
@@ -215,6 +215,6 @@ c14 = MkIsotope 6 14
 ## Conclusion
 
 This concludes this tutorial post. As can be seen, if we know the structure
-of data types in advance coming up with simple elaborator
+of data types in advance, coming up with simple elaborator
 scripts is very easy. The syntax to do so is lightweight,
 especially in cases where we can quote most of the code directly.


### PR DESCRIPTION
When working through the tutorial, I noticed a couple of minor typos, missing words, and the occasional inconsistent indentation. This should fix them (although I make no promise of having caught them all; just the ones that stood out to me).