### PR TITLE
[ refactor, new ] all about pretty printing

### DIFF
--- a/.github/workflows/ci-lib.yml
+++ b/.github/workflows/ci-lib.yml
@@ -32,3 +32,7 @@ jobs:
         run: pack typecheck elab-util
       - name: Build docs
         run: pack typecheck elab-util-docs
+      - name: Run tests
+        run: pack test elab-util
+      - name: Build elab-pretty
+        run: pack build elab-pretty

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,24 @@ docs_pkg = elab-util-docs.ipkg
 
 test_pkg = elab-util-test.ipkg
 
+PRETTIER_VERSION = 0.0.0
+
+PRETTIER_RELATIVE_DIR = prettier-${PRETTIER_VERSION}
+
 .PHONY: all
-all: lib docs test
+all: deps lib docs test
+
+./depends/${PRETTIER_RELATIVE_DIR}:
+	mkdir -p ./build/deps
+	mkdir -p ./depends
+	cd ./build/deps && \
+	git clone https://github.com/Z-snails/prettier && \
+	cd prettier && \
+	${IDRIS2} --build prettier.ipkg && \
+	cp -R ./build/ttc ../../../depends/${PRETTIER_RELATIVE_DIR}/
+
+.PHONY: deps
+deps: ./depends/${PRETTIER_RELATIVE_DIR}
 
 .PHONY: clean-install
 clean-install: clean install
@@ -40,6 +56,7 @@ install-with-src:
 clean:
 	${IDRIS2} --clean ${lib_pkg}
 	${IDRIS2} --clean ${docs_pkg}
+	${RM} -r depends
 	${RM} -r build
 
 # Start a REPL in rlwrap

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ install-with-src:
 .PHONY: clean
 clean:
 	${IDRIS2} --clean ${lib_pkg}
+	${IDRIS2} --clean ${test_pkg}
 	${IDRIS2} --clean ${docs_pkg}
 	${RM} -r depends
 	${RM} -r build

--- a/elab-pretty.ipkg
+++ b/elab-pretty.ipkg
@@ -1,0 +1,14 @@
+package elab-util
+
+authors    = "stefan-hoeck"
+brief      = "Pretty printing TTImp and friends, plus auto-deriving pretty printers"
+version    = 0.6.0
+readme     = "README.md"
+license    = "BSD-2 Clause"
+
+sourcedir  = "src"
+depends    = elab-util
+           , prettier
+
+modules = Derive.Pretty
+        , Language.Reflection.Pretty

--- a/elab-pretty.ipkg
+++ b/elab-pretty.ipkg
@@ -1,4 +1,4 @@
-package elab-util
+package elab-pretty
 
 authors    = "stefan-hoeck"
 brief      = "Pretty printing TTImp and friends, plus auto-deriving pretty printers"

--- a/elab-util-docs.ipkg
+++ b/elab-util-docs.ipkg
@@ -6,7 +6,7 @@ readme     = "README.md"
 license    = "BSD-2 Clause"
 
 sourcedir  = "src"
-depends    = contrib
+depends    = prettier
 
 modules = Doc.Derive
         , Doc.Enum1

--- a/elab-util-test.ipkg
+++ b/elab-util-test.ipkg
@@ -6,7 +6,7 @@ readme     = "README.md"
 license    = "BSD-2 Clause"
 
 sourcedir  = "src"
-depends    = contrib
+depends    = prettier
 
 main       = Test.Main
 

--- a/elab-util.ipkg
+++ b/elab-util.ipkg
@@ -8,7 +8,7 @@ license    = "BSD-2 Clause"
 
 sourcedir  = "src"
 depends    = base    >= 0.6.0
-           , contrib >= 0.6.0
+           , prettier
 
 modules = Derive.Abs
         , Derive.Eq

--- a/elab-util.ipkg
+++ b/elab-util.ipkg
@@ -8,7 +8,6 @@ license    = "BSD-2 Clause"
 
 sourcedir  = "src"
 depends    = base    >= 0.6.0
-           , prettier
 
 modules = Derive.Abs
         , Derive.Eq
@@ -26,7 +25,6 @@ modules = Derive.Abs
         , Derive.Show
 
         , Language.Reflection.Derive
-        , Language.Reflection.Pretty
         , Language.Reflection.Refined
         , Language.Reflection.Refined.Util
         , Language.Reflection.Syntax

--- a/pack.toml
+++ b/pack.toml
@@ -4,6 +4,11 @@ path = "."
 ipkg = "elab-util.ipkg"
 test = "elab-util-test.ipkg"
 
+[custom.all.elab-pretty]
+type = "local"
+path = "."
+ipkg = "elab-pretty.ipkg"
+
 [custom.all.elab-util-docs]
 type = "local"
 path = "."

--- a/src/Derive/Pretty.idr
+++ b/src/Derive/Pretty.idr
@@ -1,41 +1,126 @@
 module Derive.Pretty
 
-import public Language.Reflection.Derive
+import public Text.PrettyPrint.Bernardy
+import public Derive.Show
 
 %default total
+
+public export
+data PlaceHolder = US
+
+public export
+Pretty PlaceHolder where
+  prettyPrec _ _ = symbol '_'
 
 --------------------------------------------------------------------------------
 --          Claims
 --------------------------------------------------------------------------------
-
-||| Name of the top-level function implementing the derived `prettyPrec` function.
-public export
-(.prettyName) : Named a => a -> Name
-v.prettyName = UN $ Basic "pretty\{v.nameStr}"
 
 ||| General type of a `prettyPrec` function with the given list
 ||| of implicit and auto-implicit arguments, plus the given argument type
 ||| to be displayed.
 export
 generalPrettyType : (implicits : List Arg) -> (arg : TTImp) -> TTImp
-generalPrettyType is arg = piAll `(Prec -> ~(arg) -> Doc ann) is
+generalPrettyType is arg =
+  piAll `({opts : LayoutOpts} -> Prec -> ~(arg) -> Doc opts) is
 
 ||| Top-level function declaration implementing the `prettyPrec` function for
 ||| the given data type.
 export
-prettyClaim : Visibility -> (p : ParamTypeInfo) -> Decl
-prettyClaim vis p =
-  let tpe := generalPrettyType (allImplicits p "Pretty") p.applied
-   in simpleClaim vis p.prettyName tpe
-
-||| Name of the derived interface implementation.
-public export
-(.prettyImplName) : Named a => a -> Name
-v.prettyImplName = UN $ Basic "prettyImpl\{v.nameStr}"
+prettyClaim : Visibility -> (fun : Name) -> (p : ParamTypeInfo) -> Decl
+prettyClaim vis fun p =
+  simpleClaim vis fun (generalPrettyType (allImplicits p "Pretty") p.applied)
 
 ||| Top-level declaration of the `Pretty` implementation for the given data type.
 export
-prettyImplClaim : Visibility -> (p : ParamTypeInfo) -> Decl
-prettyImplClaim v p =
-  let tpe := piAll (var "Pretty" .$ p.applied) (allImplicits p "Pretty")
-   in implClaimVis v p.prettyImplName tpe
+prettyImplClaim : Visibility -> (impl : Name) -> (p : ParamTypeInfo) -> Decl
+prettyImplClaim v impl p = implClaimVis v impl (implType "Pretty" p)
+
+--------------------------------------------------------------------------------
+--          Definitions
+--------------------------------------------------------------------------------
+
+||| Top-level definition of the `Pretty` implementation for the given data type.
+export
+prettyImplDef : (fun, impl : Name) -> Decl
+prettyImplDef f i = def i [var i .= var "MkPretty" .$ var f]
+
+pvar : TTImp
+pvar = var "p"
+
+parameters (nms : List Name)
+  -- pretty printing a single, explicit, unnamed constructor argument
+  arg : BoundArg 1 Explicit -> TTImp
+  arg (BA (MkArg M0 _ _ _) _   _) = `(pretty US)
+  arg (BA (MkArg _  _ _ t) [x] _) = assertIfRec nms t `(prettyArg ~(varStr x))
+
+  -- prettying a constructor plus its arguments
+  rhs : Name -> SnocList TTImp -> TTImp
+  rhs n st  = `(prettyCon p ~(n.namePrim) ~(listOf st))
+
+  -- prettying a single, explicit, named constructor argument
+  narg : BoundArg 1 NamedExplicit -> TTImp
+  narg (BA a [x]   _) =
+    let nm := (argName a).namePrim
+     in case a.count of
+       M0 => `(prettyField ~(nm) US)
+       _  => assertIfRec nms a.type `(prettyField ~(nm) ~(varStr x))
+
+  -- prettying a constructor plus its named arguments
+  nrhs : Name -> SnocList TTImp -> TTImp
+  nrhs n st  = `(prettyRecord p ~(n.namePrim) ~(listOf st))
+
+  export
+  prettyClauses : (fun : Maybe Name) -> TypeInfo -> List Clause
+  prettyClauses fun ti = map clause ti.cons
+    where
+      lhs : TTImp -> TTImp
+      lhs bc = maybe bc ((.$ pvar .$ bc) . var) fun
+
+      clause : Con ti.arty ti.args -> Clause
+      clause c = case all namedArg c.args of
+        True  => accumArgs namedExplicit lhs (nrhs c.name) narg c
+        False => accumArgs explicit lhs (rhs c.name) arg c
+
+  export
+  prettyDef : Name -> TypeInfo -> Decl
+  prettyDef fun ti = def fun (prettyClauses (Just fun) ti)
+
+--------------------------------------------------------------------------------
+--          Deriving
+--------------------------------------------------------------------------------
+
+||| Derive an implementation of `Pretty a` for a custom data type `a`.
+|||
+||| Note: This is mainly to be used for indexed data types. Consider using
+|||       `derive` together with `Derive.Pretty.Pretty` for parameterized data types.
+export %macro
+derivePretty : Elab (Pretty f)
+derivePretty = do
+  Just tpe <- goal
+    | Nothing => fail "Can't infer goal"
+  let Just (resTpe, nm) := extractResult tpe
+    | Nothing => fail "Invalid goal type: \{show tpe}"
+  ti <- getInfo' nm
+
+  let impl :=  lambdaArg {a = Name} "p"
+           .=> lambdaArg {a = Name} "x"
+           .=> iCase `(x) implicitFalse (prettyClauses [ti.name] Nothing ti)
+
+  logTerm "derive.definitions" 1 "pretty implementation" impl
+  check $ var "MkPretty" .$ impl
+
+||| Generate declarations and implementations for `Pretty` for a given data type.
+export
+PrettyVis : Visibility -> List Name -> ParamTypeInfo -> Res (List TopLevel)
+PrettyVis vis nms p =
+  let fun  := funName p "prettyPrec"
+      impl := implName p "Pretty"
+   in Right [ TL (prettyClaim vis fun p) (prettyDef nms fun p.info)
+            , TL (prettyImplClaim vis impl p) (prettyImplDef fun impl)
+            ]
+
+||| Alias for `PrettyVis Public`
+export %inline
+Pretty : List Name -> ParamTypeInfo -> Res (List TopLevel)
+Pretty = PrettyVis Public

--- a/src/Derive/Show.idr
+++ b/src/Derive/Show.idr
@@ -49,9 +49,7 @@ generalShowType is arg = piAll `(Prec -> ~(arg) -> String) is
 export
 showClaim : Visibility -> (fun : Name) -> (p : ParamTypeInfo) -> Decl
 showClaim vis fun p =
-  let arg := p.applied
-      tpe := piAll `(Prec -> ~(arg) -> String) (allImplicits p "Show")
-   in simpleClaim vis fun tpe
+  simpleClaim vis fun (generalShowType (allImplicits p "Show") p.applied)
 
 ||| Top-level declaration of the `Show` implementation for the given data type.
 export

--- a/src/Doc/Enum1.md
+++ b/src/Doc/Enum1.md
@@ -41,18 +41,24 @@ structure of a typical enum type at the REPL:
 
 ```repl
 ...> :exec putPretty `[data Enum = A | B | C]
-
-  [ IData Private
-          (MkData Enum
-                  IType
-                  []
-                  [ MkTy A (IVar Enum)
-                  , MkTy B (IVar Enum)
-                  , MkTy C (IVar Enum) ]) ]
-
+[ IData
+    emptyFC
+    Private
+    Nothing
+    (MkData
+       emptyFC
+       "Enum"
+       (Just type)
+       []
+       [ mkTy {name = "A", type = var "Enum"}
+       , mkTy {name = "B", type = var "Enum"}
+       , mkTy {name = "C", type = var "Enum"}
+       ])
+]
 ```
 
-This leads to the following implementation:
+This leads to the following implementation (using the data constructors
+from `Language.Reflection`):
 
 ```idris
 enumDecl1 name cons = IData EmptyFC Public Nothing dat

--- a/src/Doc/Enum2.md
+++ b/src/Doc/Enum2.md
@@ -27,21 +27,26 @@ inspect the structure of the function we want to implement:
 
 ```repl
 ...> :exec putPretty `[eq : T -> T -> Bool; eq A A = True; eq B B = True; eq _ _ = False]
-
-
-  [ IClaim MW
-           Private
-           []
-           (MkTy eq
-                 (IPi.  (MW ExplicitArg : IVar T)
-                     -> (MW ExplicitArg : IVar T)
-                     -> IVar Bool))
-  , IDef eq
-         [ PatClause (IApp. IVar eq $ IVar A $ IVar A) (IVar True)
-         , PatClause (IApp. IVar eq $ IVar B $ IVar B) (IVar True)
-         , PatClause (IApp. IVar eq $ Implicit True $ Implicit True)
-                     (IVar False) ] ]
-
+[ IClaim
+    emptyFC
+    MW
+    Private
+    []
+    (mkTy
+       { name = "eq"
+       , type =
+               MkArg MW ExplicitArg Nothing (var "T")
+           .-> MkArg MW ExplicitArg Nothing (var "T")
+           .-> var "Bool"
+       })
+, IDef
+    emptyFC
+    "eq"
+    [ var "eq" .$ var "A" .$ var "A" .= var "True"
+    , var "eq" .$ var "B" .$ var "B" .= var "True"
+    , var "eq" .$ implicitTrue .$ implicitTrue .= var "False"
+    ]
+]
 ```
 
 So, a top-level function consists of two parts:
@@ -126,18 +131,36 @@ Pretty printing the above `TypeInfo` yields the following:
 
 ```repl
 Doc.Enum2> :exec putPretty eqInfo
-
-  MkTypeInfo Prelude.EqOrd.Eq [(MW ExplicitArg ty : IHole _)]
-    MkCon Prelude.EqOrd.MkEq
-          [ (M0 ImplicitArg ty : IType)
-          , (MW ExplicitArg == : IPi.  (MW ExplicitArg {arg:2} : IVar ty)
-                                    -> (MW ExplicitArg {arg:3} : IVar ty)
-                                    -> IVar Prelude.Basics.Bool)
-          , (MW ExplicitArg /= : IPi.  (MW ExplicitArg {arg:4} : IVar ty)
-                                    -> (MW ExplicitArg {arg:5} : IVar ty)
-                                    -> IVar Prelude.Basics.Bool) ]
-          (IApp. IVar Prelude.EqOrd.Eq $ IVar ty)
-
+MkTypeInfo
+  { name = "Prelude.EqOrd.Eq"
+  , arty = 1
+  , args = [MkArg MW ExplicitArg (Just "ty") (hole "_")]
+  , argNames = ["ty"]
+  , cons =
+      [ MkCon
+          { name = "Prelude.EqOrd.MkEq"
+          , arty = 3
+          , args =
+              [ MkArg M0 ImplicitArg (Just "ty") type
+              , MkArg
+                  MW
+                  ExplicitArg
+                  (Just "==")
+                  (    MkArg MW ExplicitArg (Just "{arg:528}") (var "ty")
+                   .-> MkArg MW ExplicitArg (Just "{arg:531}") (var "ty")
+                   .-> var "Prelude.Basics.Bool")
+              , MkArg
+                  MW
+                  ExplicitArg
+                  (Just "/=")
+                  (    MkArg MW ExplicitArg (Just "{arg:538}") (var "ty")
+                   .-> MkArg MW ExplicitArg (Just "{arg:541}") (var "ty")
+                   .-> var "Prelude.Basics.Bool")
+              ]
+          , typeArgs = [Regular (var "ty")]
+          }
+      ]
+  }
 ```
 
 ## Interface Implementation, Part 2

--- a/src/Doc/Inspect.md
+++ b/src/Doc/Inspect.md
@@ -104,7 +104,7 @@ from `Language.Reflection.Syntax`. This holds in general: Pretty printed
 `TTImp` is valid Idris code, otherwise, that's a bug.
 
 A similar layout is used for nested function declarations
-(data constructor `IPi` and infix operator `(.->))
+(data constructor `IPi` and infix operator `(.->)`)
 and lambdas (data constructor `ILam` and infix operator `(.=>)`):
 
 ```repl

--- a/src/Doc/Inspect.md
+++ b/src/Doc/Inspect.md
@@ -1,5 +1,12 @@
 # Inspecting the Structure of Idris Expressions
 
+```idris
+module Doc.Inspect
+
+import Language.Reflection.Pretty
+import Language.Reflection.Syntax
+```
+
 In this section of the tutorial, we will learn how
 to look at the underlying structure of Idris expressions.
 Most of the examples can be run from the REPL.
@@ -10,6 +17,10 @@ are provided for all public
 data types in modules `Language.Reflection.TT` and
 `Language.Reflection.TTImp`.
 
+Before we begin, make sure you have the [prettier](https://github.com/Z-snails/prettier)
+package installed, either by using the [pack](https://github.com/stefan-hoeck/idris2-pack)
+package manager (the recommended way), or by running `make deps`.
+
 Since the Idris REPL does not yet support scrolling
 through its command history, I suggest using the
 command-line utility [rlwrap](https://github.com/hanslub42/rlwrap)
@@ -17,7 +28,7 @@ to provide this functionality. The following
 command sets up our REPL for the experiments in this section:
 
 ```repl
-> rlwrap idris2 --find-ipkg src/Language/Reflection/Pretty.idr
+> rlwrap idris2 --find-ipkg src/Doc/Inspect.idr
 ```
 
 ## Quotes
@@ -33,7 +44,7 @@ constructors, functions, parameters, and variables.
 They can be quoted by putting an identifier in curly braces:
 
 ```repl
-Language.Reflection.Pretty> :t `{ Just }
+Doc.Inspect> :t `{ Just }
 UN (Basic "Just") : Name
 ```
 
@@ -42,7 +53,7 @@ data structure of the interpreted value. We can also
 prefix names with a namespace:
 
 ```repl
-Language.Reflection.Pretty> `{ Prelude.Types.Either }
+Doc.Inspect> `{ Prelude.Types.Either }
 NS (MkNS ["Types", "Prelude"]) (UN (Basic "Either"))
 ```
 
@@ -63,10 +74,10 @@ instance for `Name`.
 
 Probably the most important quoting facility
 is the ability to quote expressions. This
-results in values of type `Language.Reflection.TTImp.TTImp`
+results in values of type `Language.Reflection.TTImp.TTImp`.
 
 ```repl
-Language.Reflection.Pretty> :t `(2 * x)
+Doc.Inspect> :t `(2 * x)
 ```
 
 This will print an impressive amount of information about the structure
@@ -77,133 +88,119 @@ trying to make the underlying tree structure visible, a
 pretty printer is provided:
 
 ```repl
-Language.Reflection.Pretty> :exec putPretty `(2 * x)
-IApp fc (IApp fc (IVar fc *) (IApp fc
-                                   (IVar fc fromInteger)
-                                   (IPrimVal fc (BI 2)))) (IVar fc x)
+Doc.Inspect> :exec putPretty `(2 * x)
+var "*" .$ (var "fromInteger" .$ primVal (BI 2)) .$ var "x"
 ```
-
-As can be seen, source locations have been replaced by a
-placeholder (`fc`) and `Name`s
-are rendered without constructors. Function application is
-treated specially: The `TTImp` constructor `IApp` is shown to
-tell users which constructor was used, but nested calls to `IApp`
-are then replaced with an infix operator (`$`) to enhance readability
-and reduce the amount of parentheses. While this somewhat obfuscates
-how cascades of function application result in nested calls
-to `IApp`, it helps when verifying the correct structure of our own
-manually written `TTImp` values. In addition, `Language.Reflection.Syntax`
-provides infix operator `(.$)`, which can be used to
-conveniently define nested function applications.
+As can be seen, source locations have been removed and `Name`s are rendered
+without constructors (because there is a `FromString Name` implementation
+in `Language.Reflection.Syntax`). The data constructors `IVar` and `IPrimVal`
+have been replaced with functions `var` and `primVal`, respectively.
+Function application is treated specially:
+The TTImp constructor `IApp` has been replaced with infix operator
+`(.$)` to enhance readability and reduce the amount of parentheses.
+While this somewhat obfuscates how cascades of function application result in nested
+calls to IApp, it is still valid Idris code, because the operator comes
+from `Language.Reflection.Syntax`. This holds in general: Pretty printed
+`TTImp` is valid Idris code, otherwise, that's a bug.
 
 A similar layout is used for nested function declarations
-(data constructor `IPi` and nesting operator `->` with
-available infix operator `(.->)`)
-and lambdas (data constructor `ILam` and nesting
-operator `=>`; infix operator `(.=>)`):
+(data constructor `IPi` and infix operator `(.->))
+and lambdas (data constructor `ILam` and infix operator `(.=>)`):
 
 ```repl
-Language.Reflection.Pretty> :exec putPretty `(Show a => (val : a) -> String)
-
-  IPi.  (MW AutoImplicit : IApp. IVar Show $ IVar a)
-     -> (MW ExplicitArg val : IVar a)
-     -> IPrimVal String
-
+Doc.Inspect> :exec putPretty `(Show a => (val : a) -> String)
+    MkArg MW AutoImplicit Nothing (var "Show" .$ var "a")
+.-> MkArg MW ExplicitArg (Just "val") (var "a")
+.-> primVal (PrT StringType)
 ```
 
 ```repl
-Language.Reflection.Pretty> :exec putPretty `(\x,y => x ++ reverse y)
-
-  ILam.  (MW ExplicitArg x : IImplicit False)
-      => (MW ExplicitArg y : IImplicit False)
-      => (IApp. IVar ++ $ IVar x $ (IApp. IVar reverse $ IVar y))
-
+Doc.Inspect> :exec putPretty `(\x,y => x ++ reverse y)
+    MkArg MW ExplicitArg (Just "x") implicitFalse
+.=> MkArg MW ExplicitArg (Just "y") implicitFalse
+.=> var "++" .$ var "x" .$ (var "reverse" .$ var "y")
 ```
 
 Again, this gives a pretty clear picture about the data constructors
-involved while trying to make things somewhat more readable.
+involved while trying to make things somewhat more readable. And again, both
+examples are valid Idris syntax:
 
-Below follow some more examples, including some
-syntactic sugar dissections.
+```idris
+test : TTImp
+test =
+      MkArg MW ExplicitArg (Just "x") implicitFalse
+  .=> MkArg MW ExplicitArg (Just "y") implicitFalse
+  .=> var "++" .$ var "x" .$ (var "reverse" .$ var "y")
+```
+
+Below follow some more examples, including some syntactic sugar dissections.
 
 Case expressions:
 
 ```repl
-Language.Reflection.Pretty> :exec putPretty `(case x of { EQ => "eq"; LT => "lt"; GT => "gt" })
-
-  ICase (IVar x)
-        (IImplicit False)
-        [ PatClause (IVar EQ) (IApp. IVar fromString $ IPrimVal eq)
-        , PatClause (IVar LT) (IApp. IVar fromString $ IPrimVal lt)
-        , PatClause (IVar GT) (IApp. IVar fromString $ IPrimVal gt) ]
-
+Doc.Inspect> :exec putPretty `(case x of { EQ => "eq"; LT => "lt"; GT => "gt" })
+iCase
+  { sc = var "x"
+  , ty = implicitFalse
+  , clauses =
+      [ var "EQ" .= var "fromString" .$ primVal (Str "eq")
+      , var "LT" .= var "fromString" .$ primVal (Str "lt")
+      , var "GT" .= var "fromString" .$ primVal (Str "gt")
+      ]
+  }
 ```
 
 Let expressions:
 
 ```repl
-Language.Reflection.Pretty> :exec putPretty `(let val = show x in val == reverse val)
-
-  ILet MW
-       val
-       (Implicit True)
-       (IApp. IVar show $ IVar x)
-       (IApp. IVar == $ IVar val $ (IApp. IVar reverse $ IVar val))
-
+Doc.Inspect> :exec putPretty `(let val = show x in val == reverse val)
+iLet
+  { count = MW
+  , name = "val"
+  , type = implicitTrue
+  , val = var "show" .$ var "x"
+  , scope = var "==" .$ var "val" .$ (var "reverse" .$ var "val")
+  }
 ```
 
 If-then-else:
 
 ```repl
-Language.Reflection.Pretty> :exec putPretty `(if x then y else z)
-
-  ICase (IVar x)
-        (IVar Bool)
-        [PatClause (IVar True) (IVar y), PatClause (IVar False) (IVar z)]
-
+Doc.Inspect> :exec putPretty `(if x then y else z)
+iCase
+  { sc = var "x"
+  , ty = var "Bool"
+  , clauses = [var "True" .= var "y", var "False" .= var "z"]
+  }
 ```
 
 Idiom brackets:
 
 ```repl
-Language.Reflection.Pretty> :exec putPretty `([| fun x y |])
-
-  IApp. IVar <*>
-      $ (IApp. IVar <*> $ (IApp. IVar pure $ IVar fun) $ IVar x)
-      $ IVar y
-
-
+Doc.Inspect> :exec putPretty `([| fun x y |])
+var "<*>" .$ (var "<*>" .$ (var "pure" .$ var "fun") .$ var "x") .$ var "y"
 ```
 
 Do notation:
 
 ```repl
-Language.Reflection.Pretty> :exec putPretty `(do x <- run; action x; pure x)
-
-App. IVar >>=
-   $ IVar run
-   $ (ILam.  (MW ExplicitArg x : IImplicit False)
-          => (IApp. IVar >>=
-                  $ (IApp. IVar action $ IVar x)
-                  $ (ILam.  (MW ExplicitArg : IImplicit False)
-                         => (IApp. IVar pure $ IVar x))))
-
+Doc.Inspect> :exec putPretty `(do x <- run; action x; pure x)
+   var ">>="
+.$ var "run"
+.$ (    MkArg MW ExplicitArg (Just "x") implicitFalse
+    .=> var ">>" .$ (var "action" .$ var "x") .$ (var "pure" .$ var "x"))
 ```
 
 Monad comprehensions:
 
 ```repl
-Language.Reflection.Pretty> :exec putPretty `([x * x | x <- xs, even x])
-
-  IApp. IVar >>=
-      $ IVar xs
-      $ (ILam.  (MW ExplicitArg x : Implicit False)
-             => (IApp. IVar >>=
-                     $ (IApp. IVar guard $ (IApp. IVar even $ IVar x))
-                     $ (ILam.  (MW ExplicitArg : Implicit False)
-                            => (IApp. IVar pure
-                                    $ (IApp. IVar * $ IVar x $ IVar x)))))
-
+Doc.Inspect> :exec putPretty `([x * x | x <- xs, even x])
+   var ">>="
+.$ var "xs"
+.$ (    MkArg MW ExplicitArg (Just "x") implicitFalse
+    .=>    var ">>"
+        .$ (var "guard" .$ (var "even" .$ var "x"))
+        .$ (var "pure" .$ (var "*" .$ var "x" .$ var "x")))
 ```
 
 The syntactic sugar examples show that we can use these
@@ -219,10 +216,6 @@ by putting them in quoted brackets. In syntax files, multiline
 quotes are supported:
 
 ```idris
-module Doc.Inspect
-
-import Language.Reflection
-
 testDecl : List Decl
 testDecl = `[ export %inline
               test : Int -> Int
@@ -233,15 +226,22 @@ In the REPL, we have to separate lines by using semicolons:
 
 ```repl
 ...> :exec putPretty `[export %inline test : Int -> Int; test n = n + n]
-
-  [ IClaim MW
-           Export
-           [Inline]
-           (MkTy test (IPi. (MW ExplicitArg : IPrimVal Int) -> IPrimVal Int))
-  , IDef test
-         [ PatClause (IApp. IVar test $ IBindVar n)
-                     (IApp. IVar + $ IVar n $ IVar n) ] ]
-
+[ IClaim
+    emptyFC
+    MW
+    Export
+    [Inline]
+    (MkTy
+       emptyFC
+       emptyFC
+       "test"
+       (    MkArg MW ExplicitArg Nothing (primVal (PrT IntType))
+        .-> primVal (PrT IntType)))
+, IDef
+    emptyFC
+    "test"
+    [var "test" .$ bindVar "n" .= var "+" .$ var "n" .$ var "n"]
+]
 ```
 
 As can be seen, a top-level function consists of an `IClaim`
@@ -251,16 +251,24 @@ Inspecting quoted data declarations is also possible:
 
 ```repl
 ...> :exec putPretty `[ data Foo t = A t | B ]
-
-  [ IData Private
-          (MkData Foo
-                  (IPi. (M1 ExplicitArg : IType) -> IType)
-                  []
-                  [ MkTy A
-                         (IPi.  (M1 ExplicitArg : IBindVar t)
-                             -> (IApp. IVar Foo $ IBindVar t))
-                  , MkTy B (IApp. IVar Foo $ IBindVar t)] ]
-
+[ IData
+    emptyFC
+    Private
+    Nothing
+    (MkData
+       emptyFC
+       "Foo"
+       (Just (MkArg MW ExplicitArg Nothing type .-> type))
+       []
+       [ MkTy
+           emptyFC
+           emptyFC
+           "A"
+           (    MkArg MW ExplicitArg Nothing (bindVar "t")
+            .-> var "Foo" .$ bindVar "t")
+       , MkTy emptyFC emptyFC "B" (var "Foo" .$ bindVar "t")
+       ])
+]
 ```
 
 ## What's next

--- a/src/Doc/Inspect.md
+++ b/src/Doc/Inspect.md
@@ -78,12 +78,13 @@ pretty printer is provided:
 
 ```repl
 Language.Reflection.Pretty> :exec putPretty `(2 * x)
-
-  IApp. IVar * $ (IApp. IVar fromInteger $ IPrimVal 2) $ IVar x
-
+IApp fc (IApp fc (IVar fc *) (IApp fc
+                                   (IVar fc fromInteger)
+                                   (IPrimVal fc (BI 2)))) (IVar fc x)
 ```
 
-As can be seen, source locations have been removed and `Name`s
+As can be seen, source locations have been replaced by a
+placeholder (`fc`) and `Name`s
 are rendered without constructors. Function application is
 treated specially: The `TTImp` constructor `IApp` is shown to
 tell users which constructor was used, but nested calls to `IApp`

--- a/src/Language/Reflection/Syntax.idr
+++ b/src/Language/Reflection/Syntax.idr
@@ -120,7 +120,7 @@ x.nameStr = nameStr x.getName
 ||| Likewise, if the name is already known at the time of
 ||| writing, use quotes for defining variables directly: `(AName)
 public export %inline
-var : Name -> TTImp
+var : (name : Name) -> TTImp
 var = IVar EmptyFC
 
 ||| Creates a variable with the name of the given value.
@@ -173,13 +173,19 @@ public export %inline
 (.namePrim) : Named a => a -> TTImp
 x.namePrim = primVal $ Str x.nameStr
 
-
 ||| The type `Type`.
 |||
 ||| This is an alias for `IType EmptyFC`.
 public export %inline
 type :  TTImp
 type = IType EmptyFC
+
+||| A named hole.
+|||
+||| This is an alias for `IHole EmptyFC`.
+public export %inline
+hole :  String -> TTImp
+hole = IHole EmptyFC
 
 ||| Tries to extract a variable name from a `TTImp`.
 |||
@@ -188,6 +194,13 @@ public export
 unVar : TTImp -> Maybe Name
 unVar (IVar _ n) = Just n
 unVar _          = Nothing
+
+||| Proof search
+|||
+||| This is an alias for `ISearch EmptyFC`
+public export %inline
+iSearch : (depth : Nat) -> TTImp
+iSearch = ISearch EmptyFC
 
 --------------------------------------------------------------------------------
 --          Application
@@ -200,7 +213,7 @@ unVar _          = Nothing
 ||| Example: ```app (var "Just") (var "x")```
 |||          is equivalent to `(Just x)
 public export %inline
-app : TTImp -> TTImp -> TTImp
+app : (fun, arg : TTImp) -> TTImp
 app = IApp EmptyFC
 
 infixl 6 .$
@@ -243,6 +256,21 @@ public export %inline
 bindAll : (fun : Name) -> (args : List String) -> TTImp
 bindAll fun = appAll fun . map bindVar
 
+||| Alias for `IBindHere EmptyFC`
+public export %inline
+bindHere : (mode : BindMode) -> (val : TTImp) -> TTImp
+bindHere = IBindHere EmptyFC
+
+||| Alias for `IMustUnify EmptyFC`
+public export %inline
+mustUnify : (reason : DotReason) -> (val : TTImp) -> TTImp
+mustUnify = IMustUnify EmptyFC
+
+||| Alias for `IAs EmptyFC EmptyFC`
+public export %inline
+iAs : (side : UseSide) -> (name : Name) -> (val : TTImp) -> TTImp
+iAs = IAs EmptyFC EmptyFC
+
 ||| Applying an auto-implicit.
 |||
 ||| This is an alias for `IAutoApp EmptyFC`.
@@ -250,8 +278,15 @@ bindAll fun = appAll fun . map bindVar
 ||| Example: `autoApp (var "traverse") (var "MyApp")`
 |||          is equivalent to `(traverse @{MyApp})
 public export %inline
-autoApp : TTImp -> TTImp -> TTImp
+autoApp : (fun, arg : TTImp) -> TTImp
 autoApp = IAutoApp EmptyFC
+
+||| Application in a `with` expression
+|||
+||| This is an alias for `IWithApp EmptyFC`.
+public export %inline
+withApp : (fun, arg : TTImp) -> TTImp
+withApp = IWithApp EmptyFC
 
 ||| Named function application.
 |||
@@ -260,7 +295,7 @@ autoApp = IAutoApp EmptyFC
 ||| Example: `namedApp (var "traverse") "f" (var "MyApp")`
 |||          is equivalent to `(traverse {f = MyApp})
 public export %inline
-namedApp : TTImp -> Name -> TTImp -> TTImp
+namedApp : (fun : TTImp) -> (name : Name) -> (arg : TTImp) -> TTImp
 namedApp = INamedApp EmptyFC
 
 ||| Catch-all pattern match on a data constructor.
@@ -272,6 +307,10 @@ public export %inline
 bindAny : Named a => a -> TTImp
 bindAny n = namedApp n.nameVar (UN Underscore) implicitTrue
 
+||| Alias for `IAlternative EmptyFC`
+public export %inline
+alternative : (tpe : AltType) -> (alts : List TTImp) -> TTImp
+alternative = IAlternative EmptyFC
 --------------------------------------------------------------------------------
 --          Function Arguments
 --------------------------------------------------------------------------------
@@ -348,7 +387,7 @@ unLambda tpe                  = ([],tpe)
 |||
 ||| This passes the fields of `Arg` to `ILam EmptyFC`
 public export
-lam : Arg -> (lamTy : TTImp) -> TTImp
+lam : (arg : Arg) -> (lamTy : TTImp) -> TTImp
 lam (MkArg c p n t) = ILam EmptyFC c p n t
 
 infixr 3 .=>
@@ -366,7 +405,7 @@ public export %inline
 |||
 ||| This passes the fields of `Arg` to `IPi EmptyFC`
 public export
-pi : Arg -> (retTy : TTImp) -> TTImp
+pi : (arg : Arg) -> (retTy : TTImp) -> TTImp
 pi (MkArg c p n t) = IPi EmptyFC c p n t
 
 infixr 5 .->
@@ -422,7 +461,7 @@ public export %inline
 |||
 ||| This is an alias for `ICase EmptyFC`.
 public export %inline
-iCase : TTImp -> (ty : TTImp) -> List Clause -> TTImp
+iCase : (sc : TTImp) -> (ty : TTImp) -> (clauses : List Clause) -> TTImp
 iCase = ICase EmptyFC
 
 ||| "as"-pattern.
@@ -493,12 +532,36 @@ public export %inline
 def : Name -> List Clause -> Decl
 def = IDef EmptyFC
 
+--------------------------------------------------------------------------------
+--          Local Defs and Let
+--------------------------------------------------------------------------------
+
+||| Let bindings.
+|||
+||| This is an alias for `ILet EmptyFC`.
+public export %inline
+iLet :
+     (count : Count)
+  -> (name  : Name)
+  -> (type  : TTImp)
+  -> (val   : TTImp)
+  -> (scope : TTImp)
+  -> TTImp
+iLet = ILet EmptyFC EmptyFC
+
 ||| Local definitions
 |||
 ||| This is an alias for `ILocal EmptyFC`.
 public export %inline
-local : List Decl -> TTImp -> TTImp
+local : (decls : List Decl) -> (scope : TTImp) -> TTImp
 local = ILocal EmptyFC
+
+||| Field updates
+|||
+||| This is an alias for `IUpdate EmptyFC`.
+public export %inline
+update : (updates : List IFieldUpdate) -> (arg : TTImp) -> TTImp
+update = IUpdate EmptyFC
 
 --------------------------------------------------------------------------------
 --          Data Declarations
@@ -536,21 +599,56 @@ simpleDataExport : Name -> (cons : List ITy) -> Decl
 simpleDataExport = simpleData Export
 
 --------------------------------------------------------------------------------
---          Local Definitions
+--          Rewrite
 --------------------------------------------------------------------------------
 
-||| Let bindings.
-|||
-||| This is an alias for `ILet EmptyFC`.
+||| Alias for `IRewrite EmptyFC`
 public export %inline
-iLet :
-     Count
-  -> Name
-  -> (nTy   : TTImp)
-  -> (nVal  : TTImp)
-  -> (scope : TTImp)
-  -> TTImp
-iLet = ILet EmptyFC EmptyFC
+iRewrite : (eq,scope : TTImp) -> TTImp
+iRewrite = IRewrite EmptyFC
+
+--------------------------------------------------------------------------------
+--          Laziness
+--------------------------------------------------------------------------------
+
+||| Alias for `IDelayed EmptyFC`
+public export %inline
+iDelayed : (reason : LazyReason) -> (arg : TTImp) -> TTImp
+iDelayed = IDelayed EmptyFC
+
+||| Alias for `IDelay EmptyFC`
+public export %inline
+iDelay : (arg : TTImp) -> TTImp
+iDelay = IDelay EmptyFC
+
+||| Alias for `IForce EmptyFC`
+public export %inline
+iForce : (arg : TTImp) -> TTImp
+iForce = IForce EmptyFC
+
+--------------------------------------------------------------------------------
+--          Quotation
+--------------------------------------------------------------------------------
+
+||| Alias for `IQuote EmptyFC`
+public export %inline
+quote : TTImp -> TTImp
+quote = IQuote EmptyFC
+
+||| Alias for `IQuoteName EmptyFC`
+public export %inline
+quoteName : Name -> TTImp
+quoteName = IQuoteName EmptyFC
+
+||| Alias for `IQuoteDecl EmptyFC`
+public export %inline
+quoteDecl : List Decl -> TTImp
+quoteDecl = IQuoteDecl EmptyFC
+
+||| Alias for `IUnquote EmptyFC`
+public export %inline
+unquote : TTImp -> TTImp
+unquote = IUnquote EmptyFC
 
 --------------------------------------------------------------------------------
 --          Recursion

--- a/src/Language/Reflection/Syntax.idr
+++ b/src/Language/Reflection/Syntax.idr
@@ -216,7 +216,7 @@ public export %inline
 app : (fun, arg : TTImp) -> TTImp
 app = IApp EmptyFC
 
-infixl 6 .$
+infixl 6 .$,.@,.!
 
 ||| Infix version of `app`
 |||
@@ -281,6 +281,11 @@ public export %inline
 autoApp : (fun, arg : TTImp) -> TTImp
 autoApp = IAutoApp EmptyFC
 
+||| Infix version of `autoApp`
+public export %inline
+(.@) : TTImp -> TTImp -> TTImp
+(.@) = autoApp
+
 ||| Application in a `with` expression
 |||
 ||| This is an alias for `IWithApp EmptyFC`.
@@ -298,6 +303,11 @@ public export %inline
 namedApp : (fun : TTImp) -> (name : Name) -> (arg : TTImp) -> TTImp
 namedApp = INamedApp EmptyFC
 
+||| Infix version of `namedApp`.
+public export %inline
+(.!) : TTImp -> (Name,TTImp) -> TTImp
+s .! (n,t) = namedApp s n t
+
 ||| Catch-all pattern match on a data constructor.
 |||
 ||| Example: `bindAny "Person"`
@@ -311,6 +321,7 @@ bindAny n = namedApp n.nameVar (UN Underscore) implicitTrue
 public export %inline
 alternative : (tpe : AltType) -> (alts : List TTImp) -> TTImp
 alternative = IAlternative EmptyFC
+
 --------------------------------------------------------------------------------
 --          Function Arguments
 --------------------------------------------------------------------------------
@@ -450,6 +461,20 @@ public export %inline
 patClause : (lhs : TTImp) -> (rhs : TTImp) -> Clause
 patClause = PatClause EmptyFC
 
+||| A with clause.
+|||
+||| This is an alias for `WithClause EmptyFC`.
+public export %inline
+withClause :
+     (lhs     : TTImp)
+  -> (rig     : Count)
+  -> (wval    : TTImp)
+  -> (prf     : Maybe Name)
+  -> (flags   : List WithFlag)
+  -> (clauses : List Clause)
+  -> Clause
+withClause = WithClause EmptyFC
+
 infixr 3 .=
 
 ||| Infix alias for `patClause`
@@ -479,7 +504,7 @@ as = IAs EmptyFC EmptyFC UseLeft
 |||
 ||| This is an alias for `MkTyp EmptyFC`.
 public export %inline
-mkTy : (n : Name) -> (ty : TTImp) -> ITy
+mkTy : (name : Name) -> (type : TTImp) -> ITy
 mkTy = MkTy EmptyFC EmptyFC
 
 ||| Type declaration of a function.
@@ -487,7 +512,13 @@ mkTy = MkTy EmptyFC EmptyFC
 ||| `claim c v opts n tp` is an alias for
 ||| `IClaim EmptyFC c v opts (MkTy EmptyFC n tp)`.
 public export %inline
-claim : Count -> Visibility -> List FnOpt -> Name -> TTImp -> Decl
+claim :
+     (count : Count)
+  -> (vis   : Visibility)
+  -> (opts  : List FnOpt)
+  -> (name  : Name)
+  -> (type  : TTImp)
+  -> Decl
 claim c v opts n tp = IClaim EmptyFC c v opts (mkTy n tp)
 
 ||| `simpleClaim v n t` is an alias for `claim MW v [] (mkTy n t)`
@@ -571,8 +602,8 @@ update = IUpdate EmptyFC
 |||
 ||| This merges constructors `IData` and `MkData`.
 public export
-iData :  Visibility
-      -> Name
+iData :  (vis   : Visibility)
+      -> (name  : Name)
       -> (tycon : TTImp)
       -> (opts  : List DataOpt)
       -> (cons  : List ITy)

--- a/src/Test/Enum1.idr
+++ b/src/Test/Enum1.idr
@@ -1,0 +1,23 @@
+||| The examples in this module correspond to the REPL output shown
+||| in `Doc.Enum1`. If these no longer typecheck, the corresponding
+||| pretty printer must be fixed and the example in `Doc.Enum1` adjusted.
+module Test.Enum1
+
+import Language.Reflection.Syntax
+
+ex1 : List Decl
+ex1 =
+  [ IData
+      emptyFC
+      Private
+      Nothing
+      (MkData
+         emptyFC
+         "Enum"
+         (Just type)
+         []
+         [ mkTy {name = "A", type = var "Enum"}
+         , mkTy {name = "B", type = var "Enum"}
+         , mkTy {name = "C", type = var "Enum"}
+         ])
+  ]

--- a/src/Test/Enum2.idr
+++ b/src/Test/Enum2.idr
@@ -1,0 +1,63 @@
+||| The examples in this module correspond to the REPL output shown
+||| in `Doc.Enum2`. If these no longer typecheck, the corresponding
+||| pretty printer must be fixed and the example in `Doc.Enum2` adjusted.
+module Test.Enum2
+
+import Language.Reflection.Syntax
+import Language.Reflection.Types
+
+ex1 : List Decl
+ex1 =
+  [ IClaim
+      emptyFC
+      MW
+      Private
+      []
+      (mkTy
+         { name = "eq"
+         , type =
+                 MkArg MW ExplicitArg Nothing (var "T")
+             .-> MkArg MW ExplicitArg Nothing (var "T")
+             .-> var "Bool"
+         })
+  , IDef
+      emptyFC
+      "eq"
+      [ var "eq" .$ var "A" .$ var "A" .= var "True"
+      , var "eq" .$ var "B" .$ var "B" .= var "True"
+      , var "eq" .$ implicitTrue .$ implicitTrue .= var "False"
+      ]
+  ]
+
+ex2 : TypeInfo
+ex2 =
+  MkTypeInfo
+    { name = "Prelude.EqOrd.Eq"
+    , arty = 1
+    , args = [MkArg MW ExplicitArg (Just "ty") (hole "_")]
+    , argNames = ["ty"]
+    , cons =
+        [ MkCon
+            { name = "Prelude.EqOrd.MkEq"
+            , arty = 3
+            , args =
+                [ MkArg M0 ImplicitArg (Just "ty") type
+                , MkArg
+                    MW
+                    ExplicitArg
+                    (Just "==")
+                    (    MkArg MW ExplicitArg (Just "{arg:528}") (var "ty")
+                     .-> MkArg MW ExplicitArg (Just "{arg:531}") (var "ty")
+                     .-> var "Prelude.Basics.Bool")
+                , MkArg
+                    MW
+                    ExplicitArg
+                    (Just "/=")
+                    (    MkArg MW ExplicitArg (Just "{arg:538}") (var "ty")
+                     .-> MkArg MW ExplicitArg (Just "{arg:541}") (var "ty")
+                     .-> var "Prelude.Basics.Bool")
+                ]
+            , typeArgs = [Regular (var "ty")]
+            }
+        ]
+    }

--- a/src/Test/Generic2.idr
+++ b/src/Test/Generic2.idr
@@ -1,0 +1,143 @@
+||| The examples in this module correspond to the REPL output shown
+||| in `Doc.Generic2`. If these no longer typecheck, the corresponding
+||| pretty printer must be fixed and the example in `Doc.Generic2` adjusted.
+module Test.Generic2
+
+import Language.Reflection.Syntax
+import Language.Reflection.Types
+
+ex1 : TypeInfo
+ex1 =
+  MkTypeInfo
+    { name = "Prelude.Types.Maybe"
+    , arty = 1
+    , args = [MkArg MW ExplicitArg (Just "ty") type]
+    , argNames = ["ty"]
+    , cons =
+        [ MkCon
+            { name = "Prelude.Types.Nothing"
+            , arty = 1
+            , args = [MkArg M0 ImplicitArg (Just "ty") type]
+            , typeArgs = [Regular (var "ty")]
+            }
+        , MkCon
+            { name = "Prelude.Types.Just"
+            , arty = 2
+            , args =
+                [ MkArg M0 ImplicitArg (Just "ty") type
+                , MkArg MW ExplicitArg (Just "x") (var "ty")
+                ]
+            , typeArgs = [Regular (var "ty")]
+            }
+        ]
+    }
+
+ex2 : TypeInfo
+ex2 =
+  MkTypeInfo
+    { name = "Prelude.Types.Either"
+    , arty = 2
+    , args =
+        [ MkArg MW ExplicitArg (Just "a") type
+        , MkArg MW ExplicitArg (Just "b") type
+        ]
+    , argNames = ["a", "b"]
+    , cons =
+        [ MkCon
+            { name = "Prelude.Types.Left"
+            , arty = 3
+            , args =
+                [ MkArg M0 ImplicitArg (Just "a") type
+                , MkArg M0 ImplicitArg (Just "b") type
+                , MkArg MW ExplicitArg (Just "x") (var "a")
+                ]
+            , typeArgs = [Regular (var "a"), Regular (var "b")]
+            }
+        , MkCon
+            { name = "Prelude.Types.Right"
+            , arty = 3
+            , args =
+                [ MkArg M0 ImplicitArg (Just "a") type
+                , MkArg M0 ImplicitArg (Just "b") type
+                , MkArg MW ExplicitArg (Just "x") (var "b")
+                ]
+            , typeArgs = [Regular (var "a"), Regular (var "b")]
+            }
+        ]
+    }
+
+ex3 : TypeInfo
+ex3 =
+  MkTypeInfo
+    { name = "Data.Vect.Vect"
+    , arty = 2
+    , args =
+        [ MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+        , MkArg MW ExplicitArg (Just "elem") type
+        ]
+    , argNames = ["len", "elem"]
+    , cons =
+        [ MkCon
+            { name = "Data.Vect.Nil"
+            , arty = 1
+            , args = [MkArg M0 ImplicitArg (Just "elem") type]
+            , typeArgs = [Regular (var "Prelude.Types.Z"), Regular (var "elem")]
+            }
+        , MkCon
+            { name = "Data.Vect.(::)"
+            , arty = 4
+            , args =
+                [ MkArg M0 ImplicitArg (Just "len") (var "Prelude.Types.Nat")
+                , MkArg M0 ImplicitArg (Just "elem") type
+                , MkArg MW ExplicitArg (Just "x") (var "elem")
+                , MkArg
+                    MW
+                    ExplicitArg
+                    (Just "xs")
+                    (var "Data.Vect.Vect" .$ var "len" .$ var "elem")
+                ]
+            , typeArgs =
+                [ Regular (var "Prelude.Types.S" .$ var "len")
+                , Regular (var "elem")
+                ]
+            }
+        ]
+    }
+
+ex4 : TypeInfo
+ex4 =
+  MkTypeInfo
+    { name = "Doc.Generic2.ASum"
+    , arty = 2
+    , args =
+        [ MkArg MW ExplicitArg (Just "a") type
+        , MkArg MW ExplicitArg (Just "b") type
+        ]
+    , argNames = ["a", "b"]
+    , cons =
+        [ MkCon
+            { name = "Doc.Generic2.L"
+            , arty = 3
+            , args =
+                [ MkArg M0 ImplicitArg (Just "y") type
+                , MkArg M0 ImplicitArg (Just "x") type
+                , MkArg MW ExplicitArg (Just "{arg:8392}") (var "x")
+                ]
+            , typeArgs = [Regular (var "x"), Regular (var "y")]
+            }
+        , MkCon
+            { name = "Doc.Generic2.R"
+            , arty = 3
+            , args =
+                [ MkArg M0 ImplicitArg (Just "s") type
+                , MkArg M0 ImplicitArg (Just "t") type
+                , MkArg
+                    MW
+                    ExplicitArg
+                    (Just "{arg:8397}")
+                    (var "Prelude.Types.Maybe" .$ var "t")
+                ]
+            , typeArgs = [Regular (var "s"), Regular (var "t")]
+            }
+        ]
+    }

--- a/src/Test/Inspect.idr
+++ b/src/Test/Inspect.idr
@@ -1,0 +1,111 @@
+||| The examples in this module correspond to the REPL output shown
+||| in `Doc.Inspect`. If these no longer typecheck, the corresponding
+||| pretty printer must be fixed and the example in `Doc.Inspect` adjusted.
+module Test.Inspect
+
+import Language.Reflection.Syntax
+
+ex1 : TTImp
+ex1 = var "*" .$ (var "fromInteger" .$ primVal (BI 2)) .$ var "x"
+
+ex2 : TTImp
+ex2 =
+      MkArg MW AutoImplicit Nothing (var "Show" .$ var "a")
+  .-> MkArg MW ExplicitArg (Just "val") (var "a")
+  .-> primVal (PrT StringType)
+
+ex3 : TTImp
+ex3 =
+      MkArg MW ExplicitArg (Just "x") implicitFalse
+  .=> MkArg MW ExplicitArg (Just "y") implicitFalse
+  .=> var "++" .$ var "x" .$ (var "reverse" .$ var "y")
+
+ex4 : TTImp
+ex4 =
+  iCase
+    { sc = var "x"
+    , ty = implicitFalse
+    , clauses =
+        [ var "EQ" .= var "fromString" .$ primVal (Str "eq")
+        , var "LT" .= var "fromString" .$ primVal (Str "lt")
+        , var "GT" .= var "fromString" .$ primVal (Str "gt")
+        ]
+    }
+
+ex5 : TTImp
+ex5 =
+  iLet
+    { count = MW
+    , name = "val"
+    , type = implicitTrue
+    , val = var "show" .$ var "x"
+    , scope = var "==" .$ var "val" .$ (var "reverse" .$ var "val")
+    }
+
+ex6 : TTImp
+ex6 =
+  iCase
+    { sc = var "x"
+    , ty = var "Bool"
+    , clauses = [var "True" .= var "y", var "False" .= var "z"]
+    }
+
+ex7 : TTImp
+ex7 =
+  var "<*>" .$ (var "<*>" .$ (var "pure" .$ var "fun") .$ var "x") .$ var "y"
+
+ex8 : TTImp
+ex8 =
+     var ">>="
+  .$ var "run"
+  .$ (    MkArg MW ExplicitArg (Just "x") implicitFalse
+      .=> var ">>" .$ (var "action" .$ var "x") .$ (var "pure" .$ var "x"))
+
+ex9 : TTImp
+ex9 =
+     var ">>="
+  .$ var "xs"
+  .$ (    MkArg MW ExplicitArg (Just "x") implicitFalse
+      .=>    var ">>"
+          .$ (var "guard" .$ (var "even" .$ var "x"))
+          .$ (var "pure" .$ (var "*" .$ var "x" .$ var "x")))
+
+ex10 : List Decl
+ex10 =
+  [ IClaim
+      emptyFC
+      MW
+      Export
+      [Inline]
+      (MkTy
+         emptyFC
+         emptyFC
+         "test"
+         (    MkArg MW ExplicitArg Nothing (primVal (PrT IntType))
+          .-> primVal (PrT IntType)))
+  , IDef
+      emptyFC
+      "test"
+      [var "test" .$ bindVar "n" .= var "+" .$ var "n" .$ var "n"]
+  ]
+
+ex11 : List Decl
+ex11 =
+  [ IData
+      emptyFC
+      Private
+      Nothing
+      (MkData
+         emptyFC
+         "Foo"
+         (Just (MkArg MW ExplicitArg Nothing type .-> type))
+         []
+         [ MkTy
+             emptyFC
+             emptyFC
+             "A"
+             (    MkArg MW ExplicitArg Nothing (bindVar "t")
+              .-> var "Foo" .$ bindVar "t")
+         , MkTy emptyFC emptyFC "B" (var "Foo" .$ bindVar "t")
+         ])
+  ]

--- a/src/Test/Main.idr
+++ b/src/Test/Main.idr
@@ -1,6 +1,12 @@
 module Test.Main
 
+import Derive.Pretty
+import Language.Reflection.Pretty
 import Test.Derive
+import Test.Enum1
+import Test.Enum2
+import Test.Generic2
+import Test.Inspect
 import Test.NameLookup
 import Test.TypeInfo
 


### PR DESCRIPTION
This PR is all about pretty printing and does the following:

- [x] Ditch the dependency on contrib
- [x] Use Bernardy-style pretty printers from [prettier](https://github.com/Z-snails/prettier)
- [x] Put pretty printing stuff in a new package *elab-pretty*
- [x] Add support for auto-deriving pretty printers
- [x] Make sure all pretty printers produce valid Idris code
- [x] Adjust the docs to the new pretty printers
- [x] Add tests for all REPL examples involving pretty printers