### PR TITLE
Switch over to HVect alias in base.

### DIFF
--- a/src/Language/Reflection/Pretty.idr
+++ b/src/Language/Reflection/Pretty.idr
@@ -15,7 +15,7 @@
 |||   :exec putPretty `((1 index : Fin n) -> Vect n t -> t)
 module Language.Reflection.Pretty
 
-import public Data.HVect
+import public Data.Vect.Quantifiers
 import Data.String
 import public Language.Reflection
 import public Text.PrettyPrint.Prettyprinter


### PR DESCRIPTION
Pairs nicely with https://github.com/idris-lang/Idris2/pull/2843. Also is entirely broken prior to that PR landing in the Idris 2 project. If/when #2843 is merged, `idris2-elab-util` tests will pass again against nightly builds. I've verified that `make test` for this repo passes locally with a build of Idris based off of #2843 installed.