### PR TITLE
Revert PR #60

### DIFF
--- a/src/Derive/Eq.idr
+++ b/src/Derive/Eq.idr
@@ -2,6 +2,8 @@ module Derive.Eq
 
 import public Language.Reflection.Derive
 
+import Language.Reflection.BugFixity
+
 %default total
 
 --------------------------------------------------------------------------------
@@ -159,10 +161,9 @@ deriveEq = do
     | Nothing => fail "Invalid goal type: \{show tpe}"
   ti <- getInfo' nm
 
-  let impl :=
-           lam (lambdaArg {a = Name} "x") $
-           lam (lambdaArg {a = Name} "y") $
-           iCase `(MkPair x y) implicitFalse (eqClauses [ti.name] "MkPair" ti)
+  let impl :=  lambdaArg {a = Name} "x"
+           .=> lambdaArg {a = Name} "y"
+           .=> iCase `(MkPair x y) implicitFalse (eqClauses [ti.name] "MkPair" ti)
 
   logMsg "derive.definitions" 1 $ show impl
   check $ var "mkEq" .$ impl

--- a/src/Derive/Pretty.idr
+++ b/src/Derive/Pretty.idr
@@ -3,6 +3,8 @@ module Derive.Pretty
 import public Text.PrettyPrint.Bernardy
 import public Derive.Show
 
+import Language.Reflection.BugFixity
+
 %default total
 
 public export

--- a/src/Derive/Show.idr
+++ b/src/Derive/Show.idr
@@ -2,6 +2,8 @@ module Derive.Show
 
 import public Language.Reflection.Derive
 
+import Language.Reflection.BugFixity
+
 %default total
 
 --------------------------------------------------------------------------------
@@ -127,10 +129,9 @@ deriveShow = do
     | Nothing => fail "Invalid goal type: \{show tpe}"
   ti <- getInfo' nm
 
-  let impl :=
-           lam (lambdaArg {a = Name} "p") $
-           lam (lambdaArg {a = Name} "x") $
-           iCase `(x) implicitFalse (showClauses [ti.name] Nothing ti)
+  let impl :=  lambdaArg {a = Name} "p"
+           .=> lambdaArg {a = Name} "x"
+           .=> iCase `(x) implicitFalse (showClauses [ti.name] Nothing ti)
 
   logMsg "derive.definitions" 1 $ show impl
   check $ var "mkShowPrec" .$ impl

--- a/src/Language/Reflection/BugFixity.idr
+++ b/src/Language/Reflection/BugFixity.idr
@@ -1,0 +1,9 @@
+||| When different modules export an operator with different
+||| fixity/associativity annotations, the last one imported wins. This
+||| behaviour may introduce unexpected errors if an
+||| indirectly-imported module's fixity clashes.
+|||
+||| If you get an error about the operators (.=>), import this module
+module Language.Reflection.BugFixity
+
+infixr 3 .=>


### PR DESCRIPTION
Include a bug-fix that resets the fixity by importing `Language.Reflection.BugFixity`

That's because #2778 is [still breaking](https://github.com/idris-lang/Idris2/actions/runs/4202005040/jobs/7290052209)