### PR TITLE
[ refactor, breaking ] reduce fixity warnings in downstream projects

### DIFF
--- a/elab-util.ipkg
+++ b/elab-util.ipkg
@@ -28,4 +28,6 @@ modules = Derive.Abs
         , Language.Reflection.Refined
         , Language.Reflection.Refined.Util
         , Language.Reflection.Syntax
+        , Language.Reflection.Syntax.Ops
         , Language.Reflection.Types
+        , Language.Reflection.Util

--- a/src/Derive/Abs.idr
+++ b/src/Derive/Abs.idr
@@ -1,6 +1,6 @@
 module Derive.Abs
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 %default total
 
@@ -24,7 +24,7 @@ absImplClaim vis impl p = implClaimVis vis impl (implType "Abs" p)
 --------------------------------------------------------------------------------
 
 absImplDef : (abs, impl : Name) -> Decl
-absImplDef abs impl = def impl [var impl .= appNames "MkAbs" [abs]]
+absImplDef abs impl = def impl [patClause (var impl) (appNames "MkAbs" [abs])]
 
 parameters (nms : List Name)
   abs : BoundArg 1 Explicit -> TTImp
@@ -32,7 +32,7 @@ parameters (nms : List Name)
 
   export
   absDef : Name -> Con n vs -> Decl
-  absDef fun c = def fun [mapArgs explicit (var fun .$) abs c]
+  absDef fun c = def fun [mapArgs explicit (var fun `app`) abs c]
 
 --------------------------------------------------------------------------------
 --          Deriving

--- a/src/Derive/Fractional.idr
+++ b/src/Derive/Fractional.idr
@@ -1,6 +1,6 @@
 module Derive.Fractional
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 %default total
 
@@ -31,7 +31,8 @@ fractionalImplClaim v i p = implClaimVis v i (implType "Fractional" p)
 --------------------------------------------------------------------------------
 
 fractionalImplDef : (div, recip, impl : Name) -> Decl
-fractionalImplDef d r i = def i [var i .= appNames "MkFractional" [d, r]]
+fractionalImplDef d r i =
+  def i [patClause (var i) (appNames "MkFractional" [d, r])]
 
 div : BoundArg 2 Explicit -> TTImp
 div (BA arg [x,y] _)  = `(~(varStr x) / ~(varStr y))
@@ -42,13 +43,13 @@ recip (BA arg [x] _)  = `(recip ~(varStr x))
 export
 divDef : Name -> Con n vs -> Decl
 divDef fun c =
-  let clause := mapArgs2 explicit (\x,y => var fun .$ x .$ y) div c
+  let clause := mapArgs2 explicit (\x,y => `(~(var fun) ~(x) ~(y))) div c
    in def fun [clause]
 
 export
 recipDef : Name -> Con n vs -> Decl
 recipDef fun c =
-  let clause := mapArgs explicit (var fun .$) recip c
+  let clause := mapArgs explicit (var fun `app`) recip c
    in def fun [clause]
 
 --------------------------------------------------------------------------------

--- a/src/Derive/FromChar.idr
+++ b/src/Derive/FromChar.idr
@@ -1,6 +1,6 @@
 module Derive.FromChar
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 %default total
 
@@ -26,13 +26,14 @@ chrImplClaim v impl p = implClaimVis v impl (implType "FromChar" p)
 --------------------------------------------------------------------------------
 
 chrImplDef : (fd, impl : Name) -> Decl
-chrImplDef fd impl = def impl [var impl .= appNames "MkFromChar" [fd]]
+chrImplDef fd impl =
+  def impl [patClause (var impl) (appNames "MkFromChar" [fd])]
 
 export
 fromChrDef : Name -> Con n vs -> Decl
 fromChrDef f c =
   let t := `(fromChar n)
-   in def f [var f .$ bindVar "n" .= injArgs explicit (const t) c]
+   in def f [patClause (var f `app` bindVar "n") (injArgs explicit (const t) c)]
 
 --------------------------------------------------------------------------------
 --          Deriving

--- a/src/Derive/FromDouble.idr
+++ b/src/Derive/FromDouble.idr
@@ -1,6 +1,6 @@
 module Derive.FromDouble
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 %default total
 
@@ -26,13 +26,14 @@ dblImplClaim v impl p = implClaimVis v impl (implType "FromDouble" p)
 --------------------------------------------------------------------------------
 
 dblImplDef : (fd, impl : Name) -> Decl
-dblImplDef fd impl = def impl [var impl .= appNames "MkFromDouble" [fd]]
+dblImplDef fd impl =
+  def impl [patClause (var impl) (appNames "MkFromDouble" [fd])]
 
 export
 fromDblDef : Name -> Con n vs -> Decl
 fromDblDef f c =
   let t := `(fromDouble n)
-   in def f [var f .$ bindVar "n" .= injArgs explicit (const t) c]
+   in def f [patClause (var f `app` bindVar "n") (injArgs explicit (const t) c)]
 
 --------------------------------------------------------------------------------
 --          Deriving

--- a/src/Derive/FromString.idr
+++ b/src/Derive/FromString.idr
@@ -1,6 +1,6 @@
 module Derive.FromString
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 %default total
 
@@ -26,13 +26,14 @@ strImplClaim v impl p = implClaimVis v impl (implType "FromString" p)
 --------------------------------------------------------------------------------
 
 strImplDef : (fd, impl : Name) -> Decl
-strImplDef fd impl = def impl [var impl .= appNames "MkFromString" [fd]]
+strImplDef fd impl =
+  def impl [patClause (var impl) (appNames "MkFromString" [fd])]
 
 export
 fromStrDef : Name -> Con n vs -> Decl
 fromStrDef f c =
   let t := `(fromString n)
-   in def f [var f .$ bindVar "n" .= injArgs explicit (const t) c]
+   in def f [patClause (var f `app` bindVar "n") (injArgs explicit (const t) c)]
 
 --------------------------------------------------------------------------------
 --          Deriving

--- a/src/Derive/Integral.idr
+++ b/src/Derive/Integral.idr
@@ -1,6 +1,6 @@
 module Derive.Integral
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 %default total
 
@@ -24,7 +24,8 @@ intImplClaim v impl p = implClaimVis v impl (implType "Integral" p)
 --------------------------------------------------------------------------------
 
 intImplDef : (div, mod, impl : Name) -> Decl
-intImplDef d m impl = def impl [var impl .= appNames "MkIntegral" [d,m]]
+intImplDef d m impl =
+  def impl [patClause (var impl) (appNames "MkIntegral" [d,m])]
 
 parameters (nms : List Name)
   div : BoundArg 2 Explicit -> TTImp
@@ -36,13 +37,13 @@ parameters (nms : List Name)
   export
   divDef : Name -> Con n vs -> Decl
   divDef fun c =
-    let clause := mapArgs2 explicit (\x,y => var fun .$ x .$ y) div c
+    let clause := mapArgs2 explicit (\x,y => `(~(var fun) ~(x) ~(y))) div c
      in def fun [clause]
 
   export
   modDef : Name -> Con n vs -> Decl
   modDef fun c =
-    let clause := mapArgs2 explicit (\x,y => var fun .$ x .$ y) mod c
+    let clause := mapArgs2 explicit (\x,y => `(~(var fun) ~(x) ~(y))) mod c
      in def fun [clause]
 
 --------------------------------------------------------------------------------

--- a/src/Derive/Monoid.idr
+++ b/src/Derive/Monoid.idr
@@ -1,6 +1,6 @@
 module Derive.Monoid
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 --------------------------------------------------------------------------------
 --          Claims
@@ -27,7 +27,7 @@ monoidImplClaim v impl p = implClaimVis v impl (implType "Monoid" p)
 
 export
 monoidImplDef : (fun, impl : Name) -> Decl
-monoidImplDef f i = def i [var i .= var "MkMonoid" .$ var f]
+monoidImplDef f i = def i [patClause (var i) (var "MkMonoid" `app` var f)]
 
 rhs : Con n vs -> TTImp
 rhs = injArgs explicit (const `(neutral))
@@ -36,7 +36,7 @@ rhs = injArgs explicit (const `(neutral))
 ||| the neutral operation.
 export
 neutralDef : Name -> Con n vs -> Decl
-neutralDef f c = def f [var f .= rhs c]
+neutralDef f c = def f [patClause (var f) (rhs c)]
 
 --------------------------------------------------------------------------------
 --          Deriving

--- a/src/Derive/Neg.idr
+++ b/src/Derive/Neg.idr
@@ -1,6 +1,6 @@
 module Derive.Neg
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 %default total
 
@@ -31,7 +31,8 @@ negImplClaim v impl p = implClaimVis v impl (implType "Neg" p)
 --------------------------------------------------------------------------------
 
 negImplDef : (neg, min, impl : Name) -> Decl
-negImplDef neg min impl = def impl [var impl .= appNames "MkNeg" [neg, min]]
+negImplDef neg min impl =
+  def impl [patClause (var impl) (appNames "MkNeg" [neg, min])]
 
 minus : BoundArg 2 Explicit -> TTImp
 minus (BA arg [x,y] _)  = `(~(varStr x) - ~(varStr y))
@@ -42,13 +43,13 @@ neg (BA arg [x] _)  = `(negate ~(varStr x))
 export
 minusDef : Name -> Con n vs -> Decl
 minusDef fun c =
-  let clause := mapArgs2 explicit (\x,y => var fun .$ x .$ y) minus c
+  let clause := mapArgs2 explicit (\x,y => `(~(var fun) ~(x) ~(y))) minus c
    in def fun [clause]
 
 export
 negDef : Name -> Con n vs -> Decl
 negDef fun c =
-  let clause := mapArgs explicit (var fun .$) neg c
+  let clause := mapArgs explicit (var fun `app`) neg c
    in def fun [clause]
 
 --------------------------------------------------------------------------------

--- a/src/Derive/Num.idr
+++ b/src/Derive/Num.idr
@@ -1,6 +1,6 @@
 module Derive.Num
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 %default total
 
@@ -37,7 +37,8 @@ numImplClaim v impl p = implClaimVis v impl (implType "Num" p)
 --------------------------------------------------------------------------------
 
 numImplDef : (p, m, fi, impl : Name) -> Decl
-numImplDef p m fi impl = def impl [var impl .= appNames "MkNum" [p,m,fi]]
+numImplDef p m fi impl =
+  def impl [patClause (var impl) (appNames "MkNum" [p,m,fi])]
 
 plus : BoundArg 2 Explicit -> TTImp
 plus (BA arg [x,y] _)  = `(~(varStr x) + ~(varStr y))
@@ -51,18 +52,19 @@ fromInt _ = `(fromInteger n)
 export
 plusDef : Name -> Con n vs -> Decl
 plusDef fun c =
-  let clause := mapArgs2 explicit (\x,y => var fun .$ x .$ y) plus c
+  let clause := mapArgs2 explicit (\x,y => `(~(var fun) ~(x) ~(y))) plus c
    in def fun [clause]
 
 export
 multDef : Name -> Con n vs -> Decl
 multDef fun c =
-  let clause := mapArgs2 explicit (\x,y => var fun .$ x .$ y) mult c
+  let clause := mapArgs2 explicit (\x,y => `(~(var fun) ~(x) ~(y))) mult c
    in def fun [clause]
 
 export
 fromIntDef : Name -> Con n vs -> Decl
-fromIntDef f c = def f [var f .$ `(n) .= injArgs explicit fromInt c]
+fromIntDef f c =
+  def f [patClause `(~(var f) n) (injArgs explicit fromInt c)]
 
 --------------------------------------------------------------------------------
 --          Deriving

--- a/src/Derive/Prelude.idr
+++ b/src/Derive/Prelude.idr
@@ -13,3 +13,4 @@ import public Derive.Num
 import public Derive.Ord
 import public Derive.Semigroup
 import public Derive.Show
+import public Language.Reflection.Util

--- a/src/Derive/Pretty.idr
+++ b/src/Derive/Pretty.idr
@@ -1,6 +1,7 @@
 module Derive.Pretty
 
 import public Text.PrettyPrint.Bernardy
+import Language.Reflection.Util
 import public Derive.Show
 
 %default total
@@ -43,7 +44,7 @@ prettyImplClaim v impl p = implClaimVis v impl (implType "Pretty" p)
 ||| Top-level definition of the `Pretty` implementation for the given data type.
 export
 prettyImplDef : (fun, impl : Name) -> Decl
-prettyImplDef f i = def i [var i .= var "MkPretty" .$ var f]
+prettyImplDef f i = def i [patClause (var i) (var "MkPretty" `app` var f)]
 
 pvar : TTImp
 pvar = var "p"
@@ -75,7 +76,7 @@ parameters (nms : List Name)
   prettyClauses fun ti = map clause ti.cons
     where
       lhs : TTImp -> TTImp
-      lhs bc = maybe bc ((.$ pvar .$ bc) . var) fun
+      lhs bc = maybe bc (\x => `(~(var x) ~(pvar) ~(bc))) fun
 
       clause : Con ti.arty ti.args -> Clause
       clause c = case all namedArg c.args of
@@ -109,7 +110,7 @@ derivePretty = do
         iCase `(x) implicitFalse (prettyClauses [ti.name] Nothing ti)
 
   logTerm "derive.definitions" 1 "pretty implementation" impl
-  check $ var "MkPretty" .$ impl
+  check $ var "MkPretty" `app` impl
 
 ||| Generate declarations and implementations for `Pretty` for a given data type.
 export

--- a/src/Derive/Semigroup.idr
+++ b/src/Derive/Semigroup.idr
@@ -1,6 +1,8 @@
 module Derive.Semigroup
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
+
+%default total
 
 --------------------------------------------------------------------------------
 --          Claims
@@ -27,13 +29,14 @@ semigroupImplClaim v impl p = implClaimVis v impl (implType "Semigroup" p)
 
 export
 semigroupImplDef : (fun, impl : Name) -> Decl
-semigroupImplDef f i = def i [var i .= var "MkSemigroup" .$ var f]
+semigroupImplDef f i =
+  def i [patClause (var i) (var "MkSemigroup" `app` var f)]
 
 app : BoundArg 2 Explicit -> TTImp
 app (BA _ [x,y] _) = `(~(varStr x) <+> ~(varStr y))
 
 appClause : Name -> Con n vs -> Clause
-appClause f = mapArgs2 explicit (\x,y => var f .$ x .$ y) app
+appClause f = mapArgs2 explicit (\x,y => `(~(var f) ~(x) ~(y))) app
 
 export
 appDef : Name -> Con n vs -> Decl

--- a/src/Derive/Show.idr
+++ b/src/Derive/Show.idr
@@ -1,6 +1,6 @@
 module Derive.Show
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 %default total
 
@@ -63,7 +63,7 @@ showImplClaim v impl p = implClaimVis v impl (implType "Show" p)
 ||| Top-level definition of the `Show` implementation for the given data type.
 export
 showImplDef : (fun, impl : Name) -> Decl
-showImplDef f i = def i [var i .= var "mkShowPrec" .$ var f]
+showImplDef f i = def i [patClause (var i) (var "mkShowPrec" `app` var f)]
 
 pvar : TTImp
 pvar = var "p"
@@ -99,7 +99,7 @@ parameters (nms : List Name)
   showClauses fun ti = map clause ti.cons
     where
       lhs : TTImp -> TTImp
-      lhs bc = maybe bc ((.$ pvar .$ bc) . var) fun
+      lhs bc = maybe bc (\x => `(~(var x) ~(pvar) ~(bc))) fun
 
       clause : Con ti.arty ti.args -> Clause
       clause c = case all namedArg c.args of
@@ -133,7 +133,7 @@ deriveShow = do
            iCase `(x) implicitFalse (showClauses [ti.name] Nothing ti)
 
   logMsg "derive.definitions" 1 $ show impl
-  check $ var "mkShowPrec" .$ impl
+  check $ var "mkShowPrec" `app` impl
 
 ||| Generate declarations and implementations for `Show` for a given data type.
 export

--- a/src/Doc/Derive.md
+++ b/src/Doc/Derive.md
@@ -49,6 +49,7 @@ errors that occurred (if any).
 module Doc.Derive
 
 import Language.Reflection.Pretty
+import Data.Vect
 import Derive.Prelude
 
 %language ElabReflection
@@ -443,10 +444,13 @@ arguments are indices and which are parameters. Function `derivePattern`
 lets us do exactly that:
 
 ```idris
-%runElab derivePattern "Tree" [I,P] [Show]
+-- %runElab derivePattern "Tree" [I,P] [Show]
 ```
 
 The pattern passed to `derivePattern` makes it clear that the first
 type argument should be considered an index (or it should just be
 *i*gnored when coming up with the necessary constraints) and the
 second should be treated as a parameter.
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Doc/Enum1.md
+++ b/src/Doc/Enum1.md
@@ -6,8 +6,7 @@ therefore need some module noise to get started.
 ```idris
 module Doc.Enum1
 
-import Language.Reflection
-import Language.Reflection.Syntax
+import Language.Reflection.Util
 
 %language ElabReflection
 ```
@@ -145,3 +144,6 @@ first metaprogram. However, the implementation of `Eq Gender`
 above quickly identifies the next opportunity: Implementing
 interface instances automatically. In the [next section](Enum2.md)
 we'll give this a try.
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Doc/Enum2.md
+++ b/src/Doc/Enum2.md
@@ -5,10 +5,10 @@ First, again, some module setup stuff.
 ```idris
 module Doc.Enum2
 
+import Data.Vect.Quantifiers
 import Doc.Enum1
-import Language.Reflection
-import Language.Reflection.Syntax
-import public Language.Reflection.Types
+import Language.Reflection.Syntax.Ops
+import Language.Reflection.Util
 
 %language ElabReflection
 ```
@@ -76,7 +76,7 @@ eqDecl1 enumName cons =
 ```
 
 We make use of several new syntactic utilities from
-`Language.Reflection.Syntax`. `(.$)` is an infix operator for
+`Language.Reflection.Syntax.Ops`. `(.$)` is an infix operator for
 function application (`Language.Reflection.Syntax.app`),
 `.->` is used to declare function types. Both are chosen
 to look similar to the corresponding Idris keywords `$` and `->`.
@@ -351,3 +351,6 @@ Now that we got a first taste of automatic interface derivation, wouldn't
 it be nice, if we could not only do this for enums but for
 any feasible data type? In the [next section](Generic1.md) we look into a generic
 representations for algebraic data types.
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Doc/Generic2.md
+++ b/src/Doc/Generic2.md
@@ -11,11 +11,10 @@ types, to figure out a normalization strategy.
 ```idris
 module Doc.Generic2
 
-import public Language.Reflection.Pretty
-import public Language.Reflection.Syntax
-import public Language.Reflection.Types
+import Data.Vect.Quantifiers
+import Language.Reflection.Pretty
+import Language.Reflection.Util
 import Doc.Generic1
-import Data.Vect
 
 %language ElabReflection
 
@@ -308,3 +307,6 @@ Feel free to have a look yourself.
 
 Now we should be ready to derive `Generic` instances
 for arbitrary parameterized types. [Let's go](Generic3.md).
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Doc/Generic3.md
+++ b/src/Doc/Generic3.md
@@ -7,9 +7,8 @@ types.
 ```idris
 module Doc.Generic3
 
-import public Language.Reflection.Pretty
-import public Language.Reflection.Syntax
-import public Language.Reflection.Types
+import Language.Reflection.Pretty
+import Language.Reflection.Util
 import Doc.Generic1
 
 %language ElabReflection
@@ -57,7 +56,7 @@ genericDecl p =
 
       -- Applies parameters to type constructor, i.e. `Either a b`
       appType  = p.applied
-      genType  = `(Generic) .$ appType .$ mkCode p
+      genType  = `(Generic ~(appType) ~(mkCode p))
 
       -- Prefixes function type with implicit arguments for
       -- type parameters:
@@ -70,7 +69,8 @@ genericDecl p =
       to      = lam x $ iCase varX implicitFalse (toClauses names)
 
    in [ interfaceHint Public function funType
-      , def function [ var function .= appAll "MkGeneric" [from,to] ] ]
+      , def function [patClause (var function) (appAll "MkGeneric" [from,to])]
+      ]
 
 export
 deriveGeneric : Name -> Elab ()
@@ -119,3 +119,6 @@ treeTest5 = Refl
 This was pretty straight forward. In the [next post](Generic4.md) I'll
 have a look at
 automating the writing of `Eq` and `Ord` instances.
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Doc/Generic4.md
+++ b/src/Doc/Generic4.md
@@ -8,11 +8,15 @@ duplication.
 ```idris
 module Doc.Generic4
 
-import public Language.Reflection.Pretty
-import public Language.Reflection.Syntax
-import public Language.Reflection.Types
+import Data.List1
+import Data.Vect
+import Data.Vect.Quantifiers
 import Doc.Generic1
 import Doc.Generic3
+import Language.Reflection
+import Language.Reflection.Pretty
+import Language.Reflection.Syntax
+import Language.Reflection.Types
 
 %language ElabReflection
 ```
@@ -101,7 +105,7 @@ Generic' p =
       function = implName p "Generic"
 
       appType  = p.applied
-      genType  = `(Generic) .$ appType .$ mkCode p
+      genType  = `(Generic ~(appType) ~(mkCode p))
       funType  = piAll genType p.implicits
 
       x       = lambdaArg {a = Name} "x"
@@ -111,7 +115,7 @@ Generic' p =
       impl    = appAll "MkGeneric" [from,to]
 
    in TL (interfaceHint Public function funType)
-         (def function [var function .= impl])
+         (def function [patClause (var function) impl])
 
 ```
 
@@ -131,7 +135,7 @@ use of it via the following utility function:
 export
 implementationType : (iface : Name) -> ParamTypeInfo -> TTImp
 implementationType iface p =
-  let appIface = var iface .$ p.applied
+  let appIface = var iface `app` p.applied
    in piAll appIface (allImplicits p iface)
 ```
 
@@ -148,7 +152,7 @@ Eq' : ParamTypeInfo -> TopLevel
 Eq' p =
   let function := implName p "Eq"
    in TL (interfaceHint Public function $ implementationType "Eq" p)
-         (def function [var function .= mkEq])
+         (def function [patClause (var function) mkEq])
 ```
 
 Same for `Ord`:
@@ -171,7 +175,7 @@ Ord' : ParamTypeInfo -> TopLevel
 Ord' p =
   let function := implName p "Ord"
    in TL (interfaceHint Public function $ implementationType "Ord" p)
-         (def function [var function .= mkOrd])
+         (def function [patClause (var function) mkOrd])
 ```
 
 ## Interface Implementations for `TTImp` and Friends
@@ -268,3 +272,6 @@ Now that we have the means to derive some of the core interface
 implementations with pretty clean syntax, let us look into
 compile-time verification of these implementations.
 But first, we will try and [get back some type safety](Generic5.md).
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Doc/Generic5.md
+++ b/src/Doc/Generic5.md
@@ -6,7 +6,7 @@ some of our beloved type safety when writing elaborator scripts.
 ```idris
 module Doc.Generic5
 
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 import Doc.Generic1
 
 %hide Language.Reflection.Derive.mkEq
@@ -61,7 +61,7 @@ mkEq eq = mkEq' eq (\a,b => not $ eq a b)
 Eq' : List Name -> ParamTypeInfo -> Res (List TopLevel)
 Eq' _ p =
   let nm := implName p "Eq" -- name of implementation function
-      cl := var nm .= `(mkEq genEq) -- single clause of the function
+      cl := patClause (var nm) `(mkEq genEq) -- single clause of the function
    in Right [TL (implClaim nm (implType "Eq" p)) (def nm [cl])]
 ```
 
@@ -94,7 +94,7 @@ mkOrd comp = mkOrd' comp
 Ord' : List Name -> ParamTypeInfo -> Res (List TopLevel)
 Ord' _ p =
   let nm := implName p "Ord" -- name of implementation function
-      cl := var nm .= `(mkOrd genCompare) -- single clause of the function
+      cl := patClause (var nm) `(mkOrd genCompare) -- single clause of the function
    in Right [TL (implClaim nm (implType "Ord" p)) (def nm [cl])]
 ```
 
@@ -174,3 +174,6 @@ data type's name and type parameters.
 It was, however, possible for record constructors
 whose types we already knew but whose names we had
 to look up using elaborator reflection.
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Doc/Generic6.md
+++ b/src/Doc/Generic6.md
@@ -537,3 +537,6 @@ Going via a well-structured data type resolves all these issues.
 And that's it for this first part. We are now ready to automatically
 derive provably correct interface implementations. That second part will
 [follow shortly](Generic7.md).
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Doc/Inspect.md
+++ b/src/Doc/Inspect.md
@@ -3,8 +3,11 @@
 ```idris
 module Doc.Inspect
 
+import Data.List1
+import Language.Reflection
 import Language.Reflection.Pretty
 import Language.Reflection.Syntax
+import Language.Reflection.Syntax.Ops
 ```
 
 In this section of the tutorial, we will learn how
@@ -100,7 +103,7 @@ The TTImp constructor `IApp` has been replaced with infix operator
 `(.$)` to enhance readability and reduce the amount of parentheses.
 While this somewhat obfuscates how cascades of function application result in nested
 calls to IApp, it is still valid Idris code, because the operator comes
-from `Language.Reflection.Syntax`. This holds in general: Pretty printed
+from `Language.Reflection.Syntax.Ops`. This holds in general: Pretty printed
 `TTImp` is valid Idris code, otherwise, that's a bug.
 
 A similar layout is used for nested function declarations
@@ -277,3 +280,6 @@ Now that we now how Idris expressions can be defined
 by means of `TTImp` and `Decl`, we can start
 building them programmatically. As a first example,
 we will write a [macro for defining enumerations](Enum1.md).
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Doc/Primitives.md
+++ b/src/Doc/Primitives.md
@@ -10,7 +10,7 @@ module Doc.Primitives
 
 import Data.Maybe
 import Data.So
-import Language.Reflection.Derive
+import Language.Reflection.Util
 
 %language ElabReflection
 
@@ -218,3 +218,6 @@ This concludes this tutorial post. As can be seen, if we know the structure
 of data types in advance, coming up with simple elaborator
 scripts is very easy. The syntax to do so is lightweight,
 especially in cases where we can quote most of the code directly.
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Language/Reflection/Derive.idr
+++ b/src/Language/Reflection/Derive.idr
@@ -5,10 +5,13 @@
 ||| using the functionality provided here.
 module Language.Reflection.Derive
 
+import Data.DPair
+import Data.List1
+import Data.Vect
 import Decidable.Equality
-import public Data.DPair
-import public Language.Reflection.Syntax
-import public Language.Reflection.Types
+import Language.Reflection
+import Language.Reflection.Syntax
+import Language.Reflection.Types
 
 %language ElabReflection
 
@@ -210,7 +213,7 @@ accumArgs f lhs rhs arg c =
   let xs := freshNames "x" c.arty
       cx := bindCon c xs
       sx := map arg (boundArgs f c.args [xs])
-   in lhs cx .= rhs sx
+   in patClause (lhs cx) (rhs sx)
 
 ||| Generates a pattern clause for accumulating the arguments
 ||| of two equivalent data constructors.
@@ -250,7 +253,7 @@ accumArgs2 f lhs rhs arg c =
       cx := bindCon c xs
       cy := bindCon c ys
       sx := map arg (boundArgs f c.args [xs,ys])
-   in lhs cx cy .= rhs sx
+   in patClause (lhs cx cy) (rhs sx)
 
 ||| Generates a pattern clause for mapping the arguments
 ||| of a data constructors over a unary function.
@@ -282,7 +285,7 @@ mapArgs f lhs arg c =
   let xs := freshNames "x" c.arty
       cx := bindCon c xs
       sx := map arg (boundArgs f c.args [xs])
-   in lhs cx .= appAll c.name (sx <>> [])
+   in patClause (lhs cx) (appAll c.name $ sx <>> [])
 
 ||| Generates a pattern clause for mapping the arguments
 ||| of two data constructors over a binary function.
@@ -317,7 +320,7 @@ mapArgs2 f lhs arg c =
       cx := bindCon c xs
       cy := bindCon c ys
       sx := map arg (boundArgs f c.args [xs,ys])
-   in lhs cx cy .= appAll c.name (sx <>> [])
+   in patClause (lhs cx cy) (appAll c.name $ sx <>> [])
 
 ||| Generates a pattern clause for creating and applying
 ||| constructor arguments.
@@ -386,7 +389,7 @@ implClaim = implClaimVis Public
 ||| ```
 export
 implType : Name -> ParamTypeInfo -> TTImp
-implType n p = piAll (var n .$ p.applied) (allImplicits p n)
+implType n p = piAll (var n `app` p.applied) (allImplicits p n)
 
 ||| Extracts the innermost target of a function application.
 ||| For instance, for `Foo @{bar} baz {n = 12}`, this will extract `Foo`.

--- a/src/Language/Reflection/Pretty.idr
+++ b/src/Language/Reflection/Pretty.idr
@@ -1,12 +1,13 @@
 ||| Pretty Printing of Elab Data-Types
 |||
-||| This has not been cleaned-up so, it actually might not
-||| look very pretty.
-|||
 ||| This module can be used in the repl to evaluate, how
 ||| syntax is translated to TTImp and Decl representations.
 ||| Use `putPretty` together with a quoted expression and
 ||| inspect the underlying implementation.
+|||
+||| Note, to improve readability, some constructs are pretty printed
+||| as infix operator chains. The operators in question can be found in
+||| module `Language.Reflection.Syntax.Ops`.
 |||
 ||| REPL Examples:
 |||
@@ -17,8 +18,8 @@ module Language.Reflection.Pretty
 
 import Derive.Pretty
 import Data.String
-import Language.Reflection.Syntax
-import Language.Reflection.Types
+import Data.Vect.Quantifiers
+import Language.Reflection.Util
 
 %language ElabReflection
 %default total

--- a/src/Language/Reflection/Refined.idr
+++ b/src/Language/Reflection/Refined.idr
@@ -3,7 +3,7 @@
 module Language.Reflection.Refined
 
 import public Language.Reflection.Refined.Util
-import public Language.Reflection.Derive
+import Language.Reflection.Util
 
 %default total
 

--- a/src/Language/Reflection/Syntax/Ops.idr
+++ b/src/Language/Reflection/Syntax/Ops.idr
@@ -1,0 +1,50 @@
+||| Operator aliases for some of the functions in
+||| `Language.Reflection.Syntax`.
+|||
+||| There are placed in a separate module in order not to
+||| pollute the envirionment with additional fixity declarations.
+module Language.Reflection.Syntax.Ops
+
+import Language.Reflection
+import Language.Reflection.Syntax
+
+%default total
+
+infixl 6 .$,.@,.!
+
+||| Infix version of `app`
+|||
+||| Example: ```var "Just" .$ var "x"```
+public export %inline
+(.$) : TTImp -> TTImp -> TTImp
+(.$) = IApp EmptyFC
+
+||| Infix version of `namedApp`.
+public export %inline
+(.!) : TTImp -> (Name,TTImp) -> TTImp
+s .! (n,t) = namedApp s n t
+
+-- Use same fixity as in `Syntax.PreorderReasoning.Generic`
+infix 1 .=>
+
+||| Infix alias for `lam`.
+|||
+||| @deprecation: This is in conflict with a similar operator from
+||| `Syntax.PreorderReasoning`. It will be removed in a later commit.
+public export %inline %deprecate
+(.=>) : Arg -> TTImp -> TTImp
+(.=>) = lam
+
+infixr 5 .->
+
+||| Infix alias for `pi`.
+public export %inline
+(.->) : Arg -> TTImp -> TTImp
+(.->) = pi
+
+infixr 3 .=
+
+||| Infix alias for `patClause`
+public export %inline
+(.=) : TTImp -> TTImp -> Clause
+(.=) = patClause

--- a/src/Language/Reflection/Util.idr
+++ b/src/Language/Reflection/Util.idr
@@ -1,0 +1,11 @@
+||| This module reexports the utilities typically required to write
+||| elaborator scripts.
+module Language.Reflection.Util
+
+import public Data.List1
+import public Data.Vect.Quantifiers
+import public Data.Vect
+import public Language.Reflection
+import public Language.Reflection.Derive
+import public Language.Reflection.Syntax
+import public Language.Reflection.Types

--- a/src/Test/Enum1.idr
+++ b/src/Test/Enum1.idr
@@ -3,7 +3,7 @@
 ||| pretty printer must be fixed and the example in `Doc.Enum1` adjusted.
 module Test.Enum1
 
-import Language.Reflection.Syntax
+import Language.Reflection.Util
 
 ex1 : List Decl
 ex1 =

--- a/src/Test/Enum2.idr
+++ b/src/Test/Enum2.idr
@@ -3,8 +3,8 @@
 ||| pretty printer must be fixed and the example in `Doc.Enum2` adjusted.
 module Test.Enum2
 
-import Language.Reflection.Syntax
-import Language.Reflection.Types
+import Language.Reflection.Syntax.Ops
+import Language.Reflection.Util
 
 ex1 : List Decl
 ex1 =

--- a/src/Test/Generic2.idr
+++ b/src/Test/Generic2.idr
@@ -3,8 +3,8 @@
 ||| pretty printer must be fixed and the example in `Doc.Generic2` adjusted.
 module Test.Generic2
 
-import Language.Reflection.Syntax
-import Language.Reflection.Types
+import Language.Reflection.Syntax.Ops
+import Language.Reflection.Util
 
 ex1 : TypeInfo
 ex1 =

--- a/src/Test/Inspect.idr
+++ b/src/Test/Inspect.idr
@@ -3,7 +3,8 @@
 ||| pretty printer must be fixed and the example in `Doc.Inspect` adjusted.
 module Test.Inspect
 
-import Language.Reflection.Syntax
+import Language.Reflection.Syntax.Ops
+import Language.Reflection.Util
 
 ex1 : TTImp
 ex1 = var "*" .$ (var "fromInteger" .$ primVal (BI 2)) .$ var "x"

--- a/src/Test/NameLookup.idr
+++ b/src/Test/NameLookup.idr
@@ -1,6 +1,7 @@
 module Test.NameLookup
 
-import Language.Reflection.Syntax
+import Language.Reflection.Syntax.Ops
+import Language.Reflection.Util
 
 %language ElabReflection
 %default total

--- a/src/Test/TypeInfo.idr
+++ b/src/Test/TypeInfo.idr
@@ -1,7 +1,8 @@
 module Test.TypeInfo
 
 import Data.List
-import Language.Reflection.Types
+import Language.Reflection.Syntax.Ops
+import Language.Reflection.Util
 
 %language ElabReflection
 %default total


### PR DESCRIPTION
This is a breaking change reorganizing parts of elab-util and moving syntactic operators to their own module, which is not reexported as a default (when importing `Derive.Prelude` or `Language.Reflection.Util`). This is to reduce the amount of fixity warnings Idris issues since idris-lang/Idris2#2832

I leave this open for about two days before merging, because it is a breaking change.