### PR TITLE
[ refactor ] generalize parameter handling

### DIFF
--- a/src/Test/Derive.idr
+++ b/src/Test/Derive.idr
@@ -1,5 +1,6 @@
 module Test.Derive
 
+import Language.Reflection.Pretty
 import Derive.Prelude
 
 %default total
@@ -76,6 +77,10 @@ record Barbie a b (f : Type -> Type) where
   name : f b
   age  : f Nat
 
+info : TypeInfo
+info = getInfo "Barbie"
+
+-- %logging "derive.claims" 1
 %runElab derive "Barbie" [Show, Eq, Ord]
 
 test : Barbie Bits64 String Prelude.id
@@ -211,3 +216,14 @@ record V4 a where
 %runElab deriveIndexed "Language.Reflection.Types.MissingInfo" [Show,Eq,Ord]
 
 %runElab deriveIndexed "Language.Reflection.Types.AppArg" [Show]
+
+--------------------------------------------------------------------------------
+--          Tagged
+--------------------------------------------------------------------------------
+
+record Id (v : k) where
+  constructor MkId
+  value : Nat
+
+namespace Id
+  %runElab derive "Id" [Show,Eq,Ord,FromInteger]

--- a/src/Test/Derive.idr
+++ b/src/Test/Derive.idr
@@ -77,10 +77,6 @@ record Barbie a b (f : Type -> Type) where
   name : f b
   age  : f Nat
 
-info : TypeInfo
-info = getInfo "Barbie"
-
--- %logging "derive.claims" 1
 %runElab derive "Barbie" [Show, Eq, Ord]
 
 test : Barbie Bits64 String Prelude.id


### PR DESCRIPTION
Motivation for this change: The following did not work so far, because the (implicit) type argument `k` was not set explicitly in derived elaborator scripts:

```idris
record Id (v : k) where
  constructor MkId
  value : Nat

namespace Id
  %runElab derive "Id" [Show,Eq,Ord,FromInteger]
```

With this PR, handling implicit type constructor arguments has been fixed. Auto-implicit type constructor arguments are still being ignored. I'll have to think about those some more.