### PR TITLE
[ upstream ] Adapt IData & examples to the presence of WithDefault

### DIFF
--- a/src/Doc/Enum1.md
+++ b/src/Doc/Enum1.md
@@ -43,7 +43,7 @@ structure of a typical enum type at the REPL:
 ...> :exec putPretty `[data Enum = A | B | C]
 [ IData
     emptyFC
-    defaultValue
+    defaulted
     Nothing
     (MkData
        emptyFC
@@ -61,7 +61,7 @@ This leads to the following implementation (using the data constructors
 from `Language.Reflection`):
 
 ```idris
-enumDecl1 name cons = IData EmptyFC (value Public) Nothing dat
+enumDecl1 name cons = IData EmptyFC (specified Public) Nothing dat
 
   where
     enumName : Name

--- a/src/Doc/Enum1.md
+++ b/src/Doc/Enum1.md
@@ -43,7 +43,7 @@ structure of a typical enum type at the REPL:
 ...> :exec putPretty `[data Enum = A | B | C]
 [ IData
     emptyFC
-    Private
+    defaultValue
     Nothing
     (MkData
        emptyFC
@@ -61,7 +61,7 @@ This leads to the following implementation (using the data constructors
 from `Language.Reflection`):
 
 ```idris
-enumDecl1 name cons = IData EmptyFC Public Nothing dat
+enumDecl1 name cons = IData EmptyFC (value Public) Nothing dat
 
   where
     enumName : Name

--- a/src/Doc/Inspect.md
+++ b/src/Doc/Inspect.md
@@ -257,7 +257,7 @@ Inspecting quoted data declarations is also possible:
 ...> :exec putPretty `[ data Foo t = A t | B ]
 [ IData
     emptyFC
-    defaultValue
+    defaulted
     Nothing
     (MkData
        emptyFC

--- a/src/Doc/Inspect.md
+++ b/src/Doc/Inspect.md
@@ -257,7 +257,7 @@ Inspecting quoted data declarations is also possible:
 ...> :exec putPretty `[ data Foo t = A t | B ]
 [ IData
     emptyFC
-    Private
+    defaultValue
     Nothing
     (MkData
        emptyFC

--- a/src/Doc/Primitives.md
+++ b/src/Doc/Primitives.md
@@ -15,6 +15,7 @@ import Language.Reflection.Util
 %language ElabReflection
 
 %default total
+%hide Language.Reflection.TTImp.value
 ```
 
 ## Primitive Wrapper Types

--- a/src/Doc/Primitives.md
+++ b/src/Doc/Primitives.md
@@ -15,7 +15,6 @@ import Language.Reflection.Util
 %language ElabReflection
 
 %default total
-%hide Language.Reflection.TTImp.value
 ```
 
 ## Primitive Wrapper Types

--- a/src/Language/Reflection/Pretty.idr
+++ b/src/Language/Reflection/Pretty.idr
@@ -112,8 +112,8 @@ Pretty FC where
 export
 Pretty a => Pretty (WithDefault a def') where
   prettyPrec p withDef =
-    onWithDefault (line "defaultValue")
-                  (\v => prettyCon p "value" [prettyArg v])
+    onWithDefault (line "defaulted")
+                  (\v => prettyCon p "specified" [prettyArg v])
                   withDef
 
 %runElab derive "Count" [Pretty]

--- a/src/Language/Reflection/Pretty.idr
+++ b/src/Language/Reflection/Pretty.idr
@@ -20,6 +20,7 @@ import Derive.Pretty
 import Data.String
 import Data.Vect.Quantifiers
 import Language.Reflection.Util
+import Language.Reflection.TTImp
 
 %language ElabReflection
 %default total
@@ -108,6 +109,12 @@ export
 Pretty FC where
   prettyPrec _ _ = line "emptyFC"
 
+export
+Pretty a => Pretty (WithDefault a def') where
+  prettyPrec p withDef =
+    onWithDefault (line "defaultValue")
+                  (\v => prettyCon p "value" [prettyArg v])
+                  withDef
 
 %runElab derive "Count" [Pretty]
 %runElab derive "PiInfo" [Pretty]

--- a/src/Language/Reflection/Syntax.idr
+++ b/src/Language/Reflection/Syntax.idr
@@ -579,7 +579,7 @@ iData :
   -> (cons  : List ITy)
   -> Decl
 iData v n tycon opts cons =
-  IData EmptyFC (value v) Nothing (MkData EmptyFC n (Just tycon) opts cons)
+  IData EmptyFC (specified v) Nothing (MkData EmptyFC n (Just tycon) opts cons)
 
 ||| Simple data declaration of type `Type` (no options, no parameters,
 ||| no indices).

--- a/src/Language/Reflection/Syntax.idr
+++ b/src/Language/Reflection/Syntax.idr
@@ -579,7 +579,7 @@ iData :
   -> (cons  : List ITy)
   -> Decl
 iData v n tycon opts cons =
-  IData EmptyFC v Nothing (MkData EmptyFC n (Just tycon) opts cons)
+  IData EmptyFC (value v) Nothing (MkData EmptyFC n (Just tycon) opts cons)
 
 ||| Simple data declaration of type `Type` (no options, no parameters,
 ||| no indices).

--- a/src/Test/Enum1.idr
+++ b/src/Test/Enum1.idr
@@ -9,7 +9,7 @@ ex1 : List Decl
 ex1 =
   [ IData
       emptyFC
-      defaultValue
+      defaulted
       Nothing
       (MkData
          emptyFC

--- a/src/Test/Enum1.idr
+++ b/src/Test/Enum1.idr
@@ -9,7 +9,7 @@ ex1 : List Decl
 ex1 =
   [ IData
       emptyFC
-      Private
+      defaultValue
       Nothing
       (MkData
          emptyFC

--- a/src/Test/Inspect.idr
+++ b/src/Test/Inspect.idr
@@ -94,7 +94,7 @@ ex11 : List Decl
 ex11 =
   [ IData
       emptyFC
-      Private
+      (value Private)
       Nothing
       (MkData
          emptyFC

--- a/src/Test/Inspect.idr
+++ b/src/Test/Inspect.idr
@@ -94,7 +94,7 @@ ex11 : List Decl
 ex11 =
   [ IData
       emptyFC
-      (value Private)
+      (specified Private)
       Nothing
       (MkData
          emptyFC


### PR DESCRIPTION
C.f. https://github.com/idris-lang/Idris2/pull/3063

I've done the change non-invasively here, only adapting the implementation of `idata` instead of modifying each occurrence of `Visbility`, because explicitly specifying the default doesn't make sense (we don't use `MkLater` after all).