### PR TITLE
[ fix ] fix invalid forward declaration

### DIFF
--- a/src/Test/Derive.idr
+++ b/src/Test/Derive.idr
@@ -108,7 +108,7 @@ data Full a = Leaf a | Node (Full (a, a))
 --          Mutual Recursion
 --------------------------------------------------------------------------------
 
-data Tree : Type -> Type where
+data Tree : Type -> Type
 
 record Forest a where
   constructor MkForest


### PR DESCRIPTION
Forward declarations should not have `where` on them. A `data` with `where` is an empty type, but they ara accidentally accepted as a forward declaration.  I've filed idris-lang/Idris2#3480 to fix that issue, but it will break the elab-util build.